### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/lAvArt/Quran-corpus-visualizer/security/code-scanning/2](https://github.com/lAvArt/Quran-corpus-visualizer/security/code-scanning/2)

In general, to fix this kind of issue you add an explicit `permissions` block that grants only the scopes needed by the jobs. For typical CI jobs that just check out code, install dependencies, run lint/tests, and build artifacts (without publishing or modifying repo state), `contents: read` is sufficient and is the recommended minimal starting point.

The best fix here, without changing any existing functionality, is to add a single `permissions` block at the top (workflow) level, right after the `on:` configuration and before `concurrency:`. This will apply to all jobs (`quality` and `build`) since neither defines its own `permissions`. The block should be:

```yaml
permissions:
  contents: read
```

No extra imports or dependencies are needed; this is purely a YAML configuration change in `.github/workflows/ci.yml`.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert the `permissions` block between the existing `on:` block (ending at line 7) and the `concurrency:` block (starting at line 9).
- Leave the rest of the file unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
