### PR TITLE
Fix RTL layout and floating sidebars; add test

### DIFF
--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -27,7 +27,7 @@
   --sidebar-slide-out: 120%;
 }
 
-:root[dir="rtl"] {
+.locale-shell[dir="rtl"] {
   --sidebar-slide-out: -120%;
   text-align: right;
 }
@@ -1337,7 +1337,7 @@ body {
   border-radius: 4px;
 }
 
-:root[dir="rtl"] .ui-context-panel-header {
+.locale-shell[dir="rtl"] .ui-context-panel-header {
   flex-direction: row-reverse;
 }
 
@@ -2559,7 +2559,7 @@ button.site-footer-link {
 }
 
 .floating-sidebar {
-  position: absolute;
+  position: fixed;
   top: var(--header-clearance);
   inset-inline-end: 1rem;
   bottom: calc(var(--footer-height) + 0.5rem);
@@ -2780,9 +2780,9 @@ button.site-footer-link {
 }
 
 .floating-controls {
-  position: absolute;
+  position: fixed;
   bottom: calc(var(--footer-height) + 1rem);
-  left: 2rem;
+  inset-inline-start: 2rem;
   z-index: 10;
   pointer-events: none;
   display: flex;
@@ -2825,8 +2825,7 @@ button.site-footer-link {
 
 @media (max-width: 900px) {
   .floating-controls {
-    left: 1rem;
-    right: 1rem;
+    inset-inline: 1rem;
     bottom: calc(5.5rem + env(safe-area-inset-bottom));
   }
 
@@ -3428,7 +3427,7 @@ button.site-footer-link {
 
   .viz-legend {
     top: auto;
-    right: 1rem;
+    inset-inline-end: 1rem;
     bottom: calc(var(--footer-height) + var(--mobile-tools-bar-clearance));
     width: auto;
     max-height: 38vh;

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -94,7 +94,7 @@ export default async function RootLayout({
     <>
       <NextIntlClientProvider messages={messages}>
         <Providers>
-          <div dir={direction}>
+          <div dir={direction} lang={locale} className="locale-shell">
             {children}
             <Footer />
           </div>

--- a/tests/e2e/app-smoke.spec.ts
+++ b/tests/e2e/app-smoke.spec.ts
@@ -43,6 +43,45 @@ test.describe("app shell smoke", () => {
     await expect(page.getByTestId("app-mode-link-search")).toHaveAttribute("data-active", "true");
   });
 
+  test("arabic explore keeps pinned panels docked to viewport edges", async ({ page }) => {
+    await page.goto("/ar");
+    await page.getByRole("button", { name: /الأدوات/i }).click();
+
+    const layout = await page.evaluate(() => {
+      const getRect = (selector: string) => {
+        const element = document.querySelector(selector);
+        if (!element) return null;
+
+        const rect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+
+        return {
+          left: rect.left,
+          right: rect.right,
+          width: rect.width,
+          flexDirection: style.flexDirection,
+        };
+      };
+
+      return {
+        viewportWidth: window.innerWidth,
+        toolsSidebar: getRect(".floating-sidebar"),
+        selectionPanel: getRect(".viz-sidebar-stack"),
+        selectionHeader: getRect(".ui-context-panel-header"),
+      };
+    });
+
+    expect(layout.toolsSidebar).not.toBeNull();
+    expect(layout.selectionPanel).not.toBeNull();
+    expect(layout.selectionHeader).not.toBeNull();
+
+    expect(layout.toolsSidebar!.left).toBeLessThanOrEqual(24);
+    expect(layout.toolsSidebar!.right).toBeGreaterThan(layout.toolsSidebar!.left);
+    expect(layout.toolsSidebar!.width).toBeGreaterThan(300);
+    expect(layout.selectionPanel!.right).toBeGreaterThanOrEqual(layout.viewportWidth - 24);
+    expect(layout.selectionHeader!.flexDirection).toBe("row-reverse");
+  });
+
   test("search workspace returns a deterministic sample result", async ({ page }) => {
     await page.goto("/en/search");
 


### PR DESCRIPTION
Scope RTL styles to the root locale container by switching selectors from :root[dir="rtl"] to .locale-shell[dir="rtl"] and add lang/class to the app root in layout.tsx. Convert several floating elements from absolute to fixed positioning and replace left/right with logical properties (inset-inline-start / inset-inline-end / inset-inline) so pinned sidebars and controls stay docked to viewport edges in both LTR/RTL. Add a Playwright e2e test that loads the Arabic page and asserts the floating sidebar, selection panel, and context header are positioned and styled correctly (docked edges, width, and row-reverse flex direction).

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Screenshots / GIFs

If applicable, add screenshots or GIFs showing the change.

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`npm run test`)
- [x] Linting passes (`npm run lint`)
- [ ] Type checking passes (`npm run typecheck`)
- [ ] I have updated documentation where needed
- [x] My changes align with the [Roadmap](docs/ROADMAP.md)

## Additional Notes

Any additional context or implementation details reviewers should know.
