### PR TITLE
Add embed docs, demo page, and optimize embed loading

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,12 @@
       "Bash(grep -r search/semantic /c/Users/AvArc/RiderProjects/Quran-corpus-visualizer --include=*.tsx --include=*.ts --exclude-dir=node_modules --exclude-dir=.next)",
       "Bash(grep -r semantic /c/Users/AvArc/RiderProjects/Quran-corpus-visualizer --include=*.tsx --include=*.ts --exclude-dir=node_modules --exclude-dir=.next)",
       "Bash(grep -r \"OpenAI\\\\|embedding\\\\|OPENAI_API_KEY\" /c/Users/AvArc/RiderProjects/Quran-corpus-visualizer --include=*.md --include=*.ts --include=*.tsx --exclude-dir=node_modules --exclude-dir=.next)",
-      "Bash(npm test:*)"
+      "Bash(npm test:*)",
+      "WebFetch(domain:quran.pluragate.org)",
+      "Bash(curl -sI \"https://quran.pluragate.org/embed/root-network?surah=3&theme=dark\")",
+      "Bash(npx -y serve docs -p 3333 --no-clipboard)",
+      "Bash(gh pr:*)",
+      "Bash(gh repo:*)"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ docs/                Product, schema, roadmap, and release documentation
 - [SECURITY.md](SECURITY.md)
 - [docs/SCHEMA.md](docs/SCHEMA.md)
 - [docs/DATA_SOURCES.md](docs/DATA_SOURCES.md)
+- [docs/EMBEDDING.md](docs/EMBEDDING.md)
 - [docs/ROADMAP.md](docs/ROADMAP.md)
 
 ## Attribution

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -11,64 +11,71 @@ function isRoutingLocale(locale: string): locale is (typeof routing.locales)[num
   return routing.locales.includes(locale as (typeof routing.locales)[number]);
 }
 
-export const metadata: Metadata = {
-  title: {
-    default: "Quran Corpus Visualizer",
-    template: "%s | Quran Corpus Visualizer"
-  },
-  description: "Explore the Quran through interactive linguistic graphs, root-to-word flows, and advanced corpus visualization tools.",
-  keywords: ["Quran", "Corpus", "Visualization", "Linguistics", "Arabic", "Islam", "Data Visualization", "Graph", "Roots", "Morphology"],
-  authors: [{ name: "Quran Corpus Visualizer Team" }],
-  creator: "Quran Corpus Visualizer",
-  publisher: "Quran Corpus Visualizer",
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
-      index: true,
-      follow: true,
-      'max-video-preview': -1,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const isPseudo = locale === 'pseudo';
+
+  return {
+    title: {
+      default: "Quran Corpus Visualizer",
+      template: "%s | Quran Corpus Visualizer"
     },
-  },
-  openGraph: {
-    type: "website",
-    locale: "en_US",
-    url: "https://quran.pluragate.org",
-    title: "Quran Corpus Visualizer",
-    description: "Interactive exploration of Quranic linguistic structure and morphology.",
-    siteName: "Quran Corpus Visualizer",
-    images: [
-      {
-        url: "/opengraph-image",
-        width: 1200,
-        height: 630,
-        alt: "Quran Corpus Visualizer – Interactive Quranic linguistic exploration",
+    description: "Explore the Quran through interactive linguistic graphs, root-to-word flows, and advanced corpus visualization tools.",
+    keywords: ["Quran", "Corpus", "Visualization", "Linguistics", "Arabic", "Islam", "Data Visualization", "Graph", "Roots", "Morphology"],
+    authors: [{ name: "Quran Corpus Visualizer Team" }],
+    creator: "Quran Corpus Visualizer",
+    publisher: "Quran Corpus Visualizer",
+    robots: isPseudo
+      ? { index: false, follow: false }
+      : {
+          index: true,
+          follow: true,
+          googleBot: {
+            index: true,
+            follow: true,
+            'max-video-preview': -1,
+            'max-image-preview': 'large',
+            'max-snippet': -1,
+          },
+        },
+    openGraph: isPseudo ? undefined : {
+      type: "website",
+      locale: "en_US",
+      url: "https://quran.pluragate.org",
+      title: "Quran Corpus Visualizer",
+      description: "Interactive exploration of Quranic linguistic structure and morphology.",
+      siteName: "Quran Corpus Visualizer",
+      images: [
+        {
+          url: "/opengraph-image",
+          width: 1200,
+          height: 630,
+          alt: "Quran Corpus Visualizer – Interactive Quranic linguistic exploration",
+        },
+      ],
+    },
+    twitter: isPseudo ? undefined : {
+      card: "summary_large_image",
+      title: "Quran Corpus Visualizer",
+      description: "Deep dive into Quranic linguistics with interactive visualizations.",
+      images: ["/twitter-image"],
+      creator: "@pluragate",
+    },
+    alternates: {
+      canonical: "/",
+      languages: {
+        'en-US': '/en',
+        'ar-SA': '/ar',
       },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Quran Corpus Visualizer",
-    description: "Deep dive into Quranic linguistics with interactive visualizations.",
-    images: ["/twitter-image"],
-    creator: "@pluragate",
-  },
-  alternates: {
-    canonical: "/",
-    languages: {
-      'en-US': '/en',
-      'ar-SA': '/ar',
     },
-  },
-  manifest: "/manifest.webmanifest",
-  icons: {
-    icon: '/favicon.svg',
-    shortcut: '/favicon.svg',
-    apple: '/icon-any.svg',
-  },
-};
+    manifest: "/manifest.webmanifest",
+    icons: {
+      icon: '/favicon.svg',
+      shortcut: '/favicon.svg',
+      apple: '/icon-any.svg',
+    },
+  };
+}
 
 export default async function RootLayout({
   children,

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
         rules: {
             userAgent: '*',
             allow: '/',
-            disallow: '/private/',
+            disallow: ['/private/', '/pseudo/'],
         },
         sitemap: 'https://quran.pluragate.org/sitemap.xml',
     };

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,24 +1,62 @@
 import { MetadataRoute } from 'next';
-import { routing } from '../i18n/routing';
+
+const BASE_URL = 'https://quran.pluragate.org';
+const LOCALES = ['en', 'ar'] as const;
+
+const PAGES = [
+    { path: '',              changeFrequency: 'daily'   as const, priority: 1.0 },
+    { path: '/search',       changeFrequency: 'weekly'  as const, priority: 0.9 },
+    { path: '/study',        changeFrequency: 'weekly'  as const, priority: 0.8 },
+    { path: '/quiz',         changeFrequency: 'weekly'  as const, priority: 0.7 },
+    { path: '/auth/login',   changeFrequency: 'monthly' as const, priority: 0.3 },
+];
+
+const VIZ_MODES = [
+    'radial-sura',
+    'root-network',
+    'arc-flow',
+    'dependency-tree',
+    'sankey-flow',
+    'surah-distribution',
+    'corpus-architecture',
+    'knowledge-graph',
+    'collocation-network',
+    'heatmap',
+] as const;
 
 export default function sitemap(): MetadataRoute.Sitemap {
-    const baseUrl = 'https://quran.pluragate.org';
+    const now = new Date();
+    const entries: MetadataRoute.Sitemap = [];
 
-    // Base routes for each locale
-    const routes = routing.locales.map((locale) => ({
-        url: `${baseUrl}/${locale}`,
-        lastModified: new Date(),
-        changeFrequency: 'daily' as const,
-        priority: 1,
-    }));
+    // Root URL
+    entries.push({
+        url: BASE_URL,
+        lastModified: now,
+        changeFrequency: 'daily',
+        priority: 1.0,
+    });
 
-    // Root route (redirects)
-    const root = {
-        url: baseUrl,
-        lastModified: new Date(),
-        changeFrequency: 'daily' as const,
-        priority: 1,
-    };
+    // Locale pages
+    for (const locale of LOCALES) {
+        for (const page of PAGES) {
+            entries.push({
+                url: `${BASE_URL}/${locale}${page.path}`,
+                lastModified: now,
+                changeFrequency: page.changeFrequency,
+                priority: page.priority,
+            });
+        }
+    }
 
-    return [root, ...routes];
+    // Embed visualization routes (useful for SEO as standalone content pages)
+    for (const mode of VIZ_MODES) {
+        entries.push({
+            url: `${BASE_URL}/embed/${mode}`,
+            lastModified: now,
+            changeFrequency: 'monthly',
+            priority: 0.4,
+        });
+    }
+
+    return entries;
 }

--- a/components/embed/EmbedClient.tsx
+++ b/components/embed/EmbedClient.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { VizErrorBoundary } from "@/components/ErrorBoundary";
 import { VizControlProvider } from "@/lib/hooks/VizControlContext";
-import { loadFullCorpus } from "@/lib/corpus/corpusLoader";
+import { loadFullCorpus, loadSurahs } from "@/lib/corpus/corpusLoader";
 import { buildRootWordFlows, uniqueRoots } from "@/lib/search/rootFlows";
 import { SURAH_NAMES } from "@/lib/data/surahData";
 import type { VisualizationMode } from "@/lib/schema/visualizationTypes";
@@ -75,9 +75,15 @@ export default function EmbedClient({ vizMode, initialRoot, initialSurah, initia
   const containerRef = useRef<HTMLDivElement>(null);
 
   /* ---- data loading ------------------------------------------------ */
+  const needsFullCorpus = vizMode === "surah-distribution" || vizMode === "corpus-architecture" || vizMode === "knowledge-graph";
+
   useEffect(() => {
     let cancelled = false;
-    loadFullCorpus().then((tokens) => {
+    const loader = needsFullCorpus
+      ? loadFullCorpus()
+      : loadSurahs([selectedSurahId]);
+
+    loader.then((tokens) => {
       if (!cancelled) {
         setAllTokens(tokens);
         setLoading(false);
@@ -86,7 +92,7 @@ export default function EmbedClient({ vizMode, initialRoot, initialSurah, initia
       if (!cancelled) setLoading(false);
     });
     return () => { cancelled = true; };
-  }, []);
+  }, [needsFullCorpus, selectedSurahId]);
 
   const flows = useMemo(() => buildRootWordFlows(allTokens), [allTokens]);
   const roots = useMemo(() => uniqueRoots(allTokens), [allTokens]);

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -1,0 +1,101 @@
+# Embedding Visualizations
+
+Quran Corpus Visualizer supports embedding individual visualizations in external websites, blogs, or documentation via iframes.
+
+## Quick Start
+
+```html
+<iframe
+  src="https://quran.pluragate.org/embed/root-network?surah=3&theme=dark"
+  width="800"
+  height="600"
+  style="border:0;border-radius:8px"
+  loading="lazy"
+  allowfullscreen
+></iframe>
+```
+
+## URL Format
+
+```
+https://quran.pluragate.org/embed/{vizMode}?surah={number}&theme={light|dark}&root={root}
+```
+
+## Available Visualization Modes
+
+| Mode | Description |
+|---|---|
+| `radial-sura` | Radial Surah Map |
+| `root-network` | Root Network Graph |
+| `arc-flow` | Arc Flow |
+| `dependency-tree` | Ayah Dependency Tree |
+| `sankey-flow` | Root Flow Sankey |
+| `surah-distribution` | Surah Distribution |
+| `corpus-architecture` | Corpus Architecture |
+| `knowledge-graph` | Knowledge Graph |
+| `collocation-network` | Collocation Network |
+| `heatmap` | Heatmap |
+
+## Query Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `surah` | number | `1` | Surah number (1-114) |
+| `theme` | string | `light` | `light` or `dark` |
+| `root` | string | — | Optional Arabic root to focus on |
+
+## Examples
+
+### Root Network for Surah Al Imran (dark theme)
+
+```html
+<iframe
+  src="https://quran.pluragate.org/embed/root-network?surah=3&theme=dark"
+  width="800"
+  height="600"
+  style="border:0;border-radius:8px"
+  loading="lazy"
+  allowfullscreen
+></iframe>
+```
+
+### Radial Surah Map (light theme)
+
+```html
+<iframe
+  src="https://quran.pluragate.org/embed/radial-sura?surah=36&theme=light"
+  width="800"
+  height="600"
+  style="border:0;border-radius:8px"
+  loading="lazy"
+  allowfullscreen
+></iframe>
+```
+
+### Sankey Flow for Surah Al-Baqarah
+
+```html
+<iframe
+  src="https://quran.pluragate.org/embed/sankey-flow?surah=2&theme=dark"
+  width="800"
+  height="600"
+  style="border:0;border-radius:8px"
+  loading="lazy"
+  allowfullscreen
+></iframe>
+```
+
+## Responsive Embedding
+
+For responsive layouts, wrap the iframe in a container:
+
+```html
+<div style="position:relative;width:100%;padding-bottom:75%;overflow:hidden">
+  <iframe
+    src="https://quran.pluragate.org/embed/root-network?surah=3&theme=dark"
+    style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;border-radius:8px"
+    loading="lazy"
+    allowfullscreen
+  ></iframe>
+</div>
+```

--- a/docs/embed-demo.html
+++ b/docs/embed-demo.html
@@ -162,13 +162,18 @@
   </footer>
 
   <script>
-    const BASE = "https://quran.pluragate.org/embed";
+    const BASE_URL = "https://quran.pluragate.org/embed";
+    const VALID_MODES = new Set([
+      "root-network","radial-sura","arc-flow","dependency-tree","sankey-flow",
+      "surah-distribution","corpus-architecture","knowledge-graph","collocation-network","heatmap"
+    ]);
+    const VALID_THEMES = new Set(["dark", "light"]);
 
     const surahSelect = document.getElementById("surah");
     for (let i = 1; i <= 114; i++) {
       const opt = document.createElement("option");
-      opt.value = i;
-      opt.textContent = i;
+      opt.value = String(i);
+      opt.textContent = String(i);
       if (i === 3) opt.selected = true;
       surahSelect.appendChild(opt);
     }
@@ -177,21 +182,30 @@
       const viz   = document.getElementById("vizMode").value;
       const surah = document.getElementById("surah").value;
       const theme = document.getElementById("theme").value;
-      const src   = `${BASE}/${viz}?surah=${surah}&theme=${theme}`;
+
+      if (!VALID_MODES.has(viz) || !VALID_THEMES.has(theme)) return;
+      const surahNum = parseInt(surah, 10);
+      if (!(surahNum >= 1 && surahNum <= 114)) return;
+
+      const url = new URL(BASE_URL + "/" + viz);
+      url.searchParams.set("surah", String(surahNum));
+      url.searchParams.set("theme", theme);
+      const src = url.href;
 
       document.getElementById("preview").src = src;
 
-      const snippet =
-        `<iframe\n` +
-        `  src="${src}"\n` +
-        `  width="800"\n` +
-        `  height="600"\n` +
-        `  style="border:0;border-radius:8px"\n` +
-        `  loading="lazy"\n` +
-        `  allowfullscreen\n` +
-        `></iframe>`;
-
-      document.getElementById("code").textContent = snippet;
+      const codeEl = document.getElementById("code");
+      while (codeEl.firstChild) codeEl.firstChild.remove();
+      codeEl.appendChild(document.createTextNode(
+        '<iframe\n' +
+        '  src="' + src + '"\n' +
+        '  width="800"\n' +
+        '  height="600"\n' +
+        '  style="border:0;border-radius:8px"\n' +
+        '  loading="lazy"\n' +
+        '  allowfullscreen\n' +
+        '></iframe>'
+      ));
     }
 
     document.getElementById("vizMode").addEventListener("change", update);
@@ -201,7 +215,7 @@
     document.getElementById("copy").addEventListener("click", function () {
       navigator.clipboard.writeText(document.getElementById("code").textContent);
       this.textContent = "Copied!";
-      setTimeout(() => { this.textContent = "Copy"; }, 1500);
+      setTimeout(function () { document.getElementById("copy").textContent = "Copy"; }, 1500);
     });
 
     update();

--- a/docs/embed-demo.html
+++ b/docs/embed-demo.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quran Corpus Visualizer — Embed Demo</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: #0f1117;
+      color: #e4e4e7;
+      padding: 2rem;
+    }
+
+    h1 {
+      text-align: center;
+      font-size: 1.75rem;
+      margin-bottom: .5rem;
+    }
+
+    .subtitle {
+      text-align: center;
+      color: #a1a1aa;
+      margin-bottom: 2rem;
+    }
+
+    .controls {
+      display: flex;
+      justify-content: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 2rem;
+    }
+
+    .controls label {
+      display: flex;
+      align-items: center;
+      gap: .5rem;
+      font-size: .875rem;
+      color: #a1a1aa;
+    }
+
+    .controls select {
+      background: #1e1e2e;
+      color: #e4e4e7;
+      border: 1px solid #333;
+      border-radius: 6px;
+      padding: .4rem .6rem;
+      font-size: .875rem;
+    }
+
+    .embed-container {
+      position: relative;
+      width: 100%;
+      max-width: 900px;
+      margin: 0 auto 1.5rem;
+      padding-bottom: 56.25%;
+      border-radius: 10px;
+      overflow: hidden;
+      background: #1e1e2e;
+    }
+
+    .embed-container iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      border: 0;
+    }
+
+    .snippet {
+      max-width: 900px;
+      margin: 0 auto 3rem;
+      background: #1e1e2e;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      font-family: "Fira Code", "Cascadia Code", monospace;
+      font-size: .8rem;
+      color: #a5d6ff;
+      white-space: pre-wrap;
+      word-break: break-all;
+      position: relative;
+    }
+
+    .snippet button {
+      position: absolute;
+      top: .5rem;
+      right: .5rem;
+      background: #333;
+      color: #e4e4e7;
+      border: none;
+      border-radius: 4px;
+      padding: .3rem .6rem;
+      font-size: .75rem;
+      cursor: pointer;
+    }
+
+    .snippet button:hover { background: #444; }
+
+    footer {
+      text-align: center;
+      color: #52525b;
+      font-size: .75rem;
+      margin-top: 2rem;
+    }
+
+    footer a { color: #a1a1aa; }
+  </style>
+</head>
+<body>
+
+  <h1>Embed Demo</h1>
+  <p class="subtitle">Preview embeddable Quran Corpus visualizations and grab the iframe snippet.</p>
+
+  <div class="controls">
+    <label>
+      Visualization
+      <select id="vizMode">
+        <option value="root-network">Root Network</option>
+        <option value="radial-sura">Radial Surah Map</option>
+        <option value="arc-flow">Arc Flow</option>
+        <option value="dependency-tree">Dependency Tree</option>
+        <option value="sankey-flow">Sankey Flow</option>
+        <option value="surah-distribution">Surah Distribution</option>
+        <option value="corpus-architecture">Corpus Architecture</option>
+        <option value="knowledge-graph">Knowledge Graph</option>
+        <option value="collocation-network">Collocation Network</option>
+        <option value="heatmap">Heatmap</option>
+      </select>
+    </label>
+
+    <label>
+      Surah
+      <select id="surah"></select>
+    </label>
+
+    <label>
+      Theme
+      <select id="theme">
+        <option value="dark">Dark</option>
+        <option value="light">Light</option>
+      </select>
+    </label>
+  </div>
+
+  <div class="embed-container">
+    <iframe id="preview" loading="lazy" allowfullscreen></iframe>
+  </div>
+
+  <div class="snippet">
+    <button id="copy">Copy</button>
+    <code id="code"></code>
+  </div>
+
+  <footer>
+    <a href="https://github.com/lAvArt/Quran-corpus-visualizer" target="_blank">Quran Corpus Visualizer</a>
+    &mdash; see <a href="EMBEDDING.md">docs/EMBEDDING.md</a> for full reference.
+  </footer>
+
+  <script>
+    const BASE = "https://quran.pluragate.org/embed";
+
+    const surahSelect = document.getElementById("surah");
+    for (let i = 1; i <= 114; i++) {
+      const opt = document.createElement("option");
+      opt.value = i;
+      opt.textContent = i;
+      if (i === 3) opt.selected = true;
+      surahSelect.appendChild(opt);
+    }
+
+    function update() {
+      const viz   = document.getElementById("vizMode").value;
+      const surah = document.getElementById("surah").value;
+      const theme = document.getElementById("theme").value;
+      const src   = `${BASE}/${viz}?surah=${surah}&theme=${theme}`;
+
+      document.getElementById("preview").src = src;
+
+      const snippet =
+        `<iframe\n` +
+        `  src="${src}"\n` +
+        `  width="800"\n` +
+        `  height="600"\n` +
+        `  style="border:0;border-radius:8px"\n` +
+        `  loading="lazy"\n` +
+        `  allowfullscreen\n` +
+        `></iframe>`;
+
+      document.getElementById("code").textContent = snippet;
+    }
+
+    document.getElementById("vizMode").addEventListener("change", update);
+    document.getElementById("surah").addEventListener("change", update);
+    document.getElementById("theme").addEventListener("change", update);
+
+    document.getElementById("copy").addEventListener("click", function () {
+      navigator.clipboard.writeText(document.getElementById("code").textContent);
+      this.textContent = "Copied!";
+      setTimeout(() => { this.textContent = "Copy"; }, 1500);
+    });
+
+    update();
+  </script>
+</body>
+</html>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quran-corpus-visualizer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Interactive exploration of Quranic linguistic structure and morphology through dynamic visualizations",
   "license": "GPL-3.0",
   "private": false,


### PR DESCRIPTION
## Summary
- **docs/EMBEDDING.md** — Full reference for embedding visualizations via iframe (all 10 viz modes, query params, responsive pattern)
- **docs/embed-demo.html** — Interactive standalone page to preview embeds and copy iframe snippets
- **EmbedClient optimization** — Surah-scoped visualizations now load only the requested surah via `loadSurahs()` instead of the full corpus, significantly reducing embed load time
- **README** — Added link to embedding docs

## Test plan
- [ ] Open `docs/embed-demo.html` via a local server and verify iframe loads
- [ ] Switch visualization modes and surahs in the demo controls
- [ ] Verify embed route still works: `/embed/root-network?surah=3&theme=dark`
- [ ] Confirm full-corpus visualizations (`surah-distribution`, `corpus-architecture`, `knowledge-graph`) still load correctly in embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)