### PR TITLE
Intro/tutorial video capture harness (code only — media excluded)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ arabic-book-corpus-platform/
 
 # UX screenshot harness output
 .ux-shots/
+
+# Video captures (intro/tutorial recordings) — never commit media
+*.webm
+*.mp4

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "dotenv-cli": "^11.0.0",
         "eslint": "9.39.2",
         "eslint-config-next": "16.1.6",
+        "ffmpeg-static": "^5.3.0",
         "globals": "^17.3.0",
         "jsdom": "^28.0.0",
         "start-server-and-test": "^2.1.3",
@@ -515,6 +516,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -4725,6 +4742,13 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4804,6 +4828,13 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -4911,6 +4942,22 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/concurrently": {
       "version": "9.2.1",
@@ -5751,6 +5798,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
@@ -6561,6 +6618,50 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -7076,6 +7177,23 @@
         "node": ">= 14"
       }
     },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7182,6 +7300,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -8565,6 +8690,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -8774,6 +8905,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8875,6 +9016,21 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -9116,6 +9272,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -9540,6 +9717,16 @@
       "license": "MIT",
       "dependencies": {
         "duplexer": "~0.1.1"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -10128,6 +10315,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
@@ -10297,6 +10491,13 @@
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "dotenv-cli": "^11.0.0",
     "eslint": "9.39.2",
     "eslint-config-next": "16.1.6",
+    "ffmpeg-static": "^5.3.0",
     "globals": "^17.3.0",
     "jsdom": "^28.0.0",
     "start-server-and-test": "^2.1.3",

--- a/scripts/intro-video.ts
+++ b/scripts/intro-video.ts
@@ -1,0 +1,436 @@
+/**
+ * Intro/help video capture harness — guided-tutorial edition.
+ *
+ * Records REAL app footage with Playwright's screencast. Structural rules,
+ * learned the hard way:
+ *  - The corpus warms up FIRST under the opening card (recording runs; the
+ *    warm-up stretch is trimmed with ffmpeg), so every visible frame says
+ *    "Full corpus ready".
+ *  - ONE SPA session throughout: scene changes navigate via the app's own UI
+ *    (brand link, rail buttons, CTAs) — goto/setContent would drop the
+ *    client-side corpus cache.
+ *  - Title cards are persistent in-page overlays that CROSSFADE between
+ *    slides and only lift when a scene starts — the app never flashes
+ *    through between cards.
+ *  - A lower-third caption narrates each beat (the "real tutorial" layer).
+ *  - Cursor animates fully in-page (rAF); output re-encoded to CFR 30fps
+ *    H.264 (raw screencast is VFR → flicker).
+ *
+ * Usage: npx tsx scripts/intro-video.ts [--base http://localhost:3000]
+ *        [--locale en] [--out .ux-shots/intro-video]
+ */
+import { chromium, type Page } from "@playwright/test";
+import { execFileSync } from "child_process";
+import { createRequire } from "module";
+import path from "path";
+import { promises as fs } from "fs";
+
+const require = createRequire(import.meta.url);
+
+function arg(name: string, fallback: string): string {
+    const idx = process.argv.indexOf(`--${name}`);
+    return idx >= 0 && process.argv[idx + 1] ? process.argv[idx + 1] : fallback;
+}
+
+const BASE = arg("base", "http://localhost:3000").replace(/\/$/, "");
+const LOCALE = arg("locale", "en");
+const OUT_DIR = arg("out", ".ux-shots/intro-video");
+
+const W = 1920;
+const H = 1080;
+const CORPUS_READY_TIMEOUT_MS = 240_000;
+
+interface Slide { step?: string; heading: string; sub: string }
+interface Copy {
+    welcome: Slide;
+    ready: Slide;
+    s1: Slide; s2: Slide; s3: Slide; s4: Slide;
+    close: Slide;
+    cap: Record<string, string>;
+}
+
+const COPY: Record<string, Copy> = {
+    en: {
+        welcome: { heading: "Welcome to the Quran Observatory", sub: "A 90-second guided tour" },
+        ready: { heading: "Every word has a root", sub: "1,600+ roots, 77,000+ words — all explorable" },
+        s1: { step: "Step 1", heading: "Search any root", sub: "Arabic or English — just start typing" },
+        s2: { step: "Step 2", heading: "Read it in context", sub: "One surah, every word, on a ring" },
+        s3: { step: "Step 3", heading: "Study the root's network", sub: "Closest companions first, then the whole field" },
+        s4: { step: "Step 4", heading: "Inspect and track", sub: "Morphology on click — build your study list" },
+        close: { heading: "Now explore it yourself", sub: "quranobservatory.org" },
+        cap: {
+            type: "Type any root — try رحم (mercy)",
+            profile: "Instant profile: occurrences, meaning, and where it lives",
+            cta: "“See it in context” opens the surah map",
+            zoom: "Zoom in — every word appears in place",
+            network: "Its strongest companions orbit closest",
+            expand: "“Show full network” reveals the whole field",
+            drag: "Drag any root — it stays where you drop it",
+            inspect: "Click a root for its full morphology",
+            track: "Track it — it joins your study list",
+        },
+    },
+    ar: {
+        welcome: { heading: "مرحبًا بك في مرصد اللسانيات القرآنية", sub: "جولة إرشادية في ٩٠ ثانية" },
+        ready: { heading: "لكل كلمة جذر", sub: "أكثر من ١٦٠٠ جذر و٧٧ ألف كلمة — كلها قابلة للاستكشاف" },
+        s1: { step: "الخطوة ١", heading: "ابحث عن أي جذر", sub: "بالعربية أو الإنجليزية — ابدأ الكتابة فحسب" },
+        s2: { step: "الخطوة ٢", heading: "اقرأه في سياقه", sub: "سورة واحدة، كل كلماتها، على حلقة" },
+        s3: { step: "الخطوة ٣", heading: "ادرس شبكة الجذر", sub: "أقرب مرافقيه أولًا، ثم الحقل الكامل" },
+        s4: { step: "الخطوة ٤", heading: "افحص وتتبّع", sub: "الصرف بنقرة — وابنِ قائمة دراستك" },
+        close: { heading: "الآن استكشف بنفسك", sub: "quranobservatory.org" },
+        cap: {
+            type: "اكتب أي جذر — جرّب رحم",
+            profile: "ملف فوري: التكرارات والمعنى ومواضع الورود",
+            cta: "«شاهده في سياقه» يفتح خريطة السورة",
+            zoom: "كبّر — تظهر كل كلمة في موضعها",
+            network: "أقوى مرافقيه يدورون في المدار الأقرب",
+            expand: "«عرض الشبكة الكاملة» يكشف الحقل كله",
+            drag: "اسحب أي جذر — يبقى حيث تتركه",
+            inspect: "انقر على جذر لعرض صرفه الكامل",
+            track: "تتبّعه — ينضم إلى قائمة دراستك",
+        },
+    },
+};
+const copy = COPY[LOCALE] ?? COPY.en;
+const RTL = LOCALE === "ar";
+
+/** In-page helpers: cursor + persistent crossfading cards + caption bar. */
+const PAGE_HELPERS = `
+  (() => {
+    const ensureCursor = () => {
+      let el = document.getElementById("qcv-cursor");
+      if (el) return el;
+      el = document.createElement("div");
+      el.id = "qcv-cursor";
+      el.style.cssText = [
+        "position:fixed", "z-index:2147483647", "width:26px", "height:26px",
+        "border-radius:50%", "pointer-events:none", "top:0", "left:0",
+        "background:radial-gradient(circle, rgba(232,146,74,0.95) 0%, rgba(232,146,74,0.35) 55%, transparent 75%)",
+        "box-shadow:0 0 16px rgba(232,146,74,0.55)",
+        "transform:translate(-50%,-50%)",
+      ].join(";");
+      (document.body ?? document.documentElement).appendChild(el);
+      return el;
+    };
+    window.__qcvGlide = (x, y, ms) => new Promise((resolve) => {
+      const el = ensureCursor();
+      const x0 = parseFloat(el.style.left) || x;
+      const y0 = parseFloat(el.style.top) || y;
+      const t0 = performance.now();
+      const ease = (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
+      const step = (now) => {
+        const t = Math.min(1, (now - t0) / ms);
+        const k = ease(t);
+        el.style.left = (x0 + (x - x0) * k) + "px";
+        el.style.top = (y0 + (y - y0) * k) + "px";
+        if (t < 1) requestAnimationFrame(step);
+        else resolve(undefined);
+      };
+      requestAnimationFrame(step);
+    });
+    window.__qcvPulse = () => {
+      const el = ensureCursor();
+      el.animate(
+        [{ transform: "translate(-50%,-50%) scale(1)" }, { transform: "translate(-50%,-50%) scale(1.8)" }, { transform: "translate(-50%,-50%) scale(1)" }],
+        { duration: 260, easing: "ease-out" }
+      );
+    };
+
+    // Persistent card layer: shows/crossfades slides, only __qcvCardHide
+    // reveals the app — no gaps between consecutive slides.
+    const cardLayer = () => {
+      let layer = document.getElementById("qcv-card");
+      if (layer) return layer;
+      layer = document.createElement("div");
+      layer.id = "qcv-card";
+      layer.style.cssText = [
+        "position:fixed", "inset:0", "z-index:2147483646", "display:grid",
+        "place-content:center", "text-align:center",
+        "background:#0E161A", "opacity:0", "transition:opacity 300ms ease",
+        "color:#ECE4D8",
+        // The layer persists (for crossfades) — it must NEVER intercept the
+        // real clicks the scenes make while it's faded out.
+        "pointer-events:none",
+      ].join(";");
+      document.body.appendChild(layer);
+      return layer;
+    };
+    window.__qcvCardShow = (step, heading, sub, rtl) => new Promise((resolve) => {
+      const layer = cardLayer();
+      const inner = document.createElement("div");
+      inner.style.cssText = "display:grid;gap:16px;opacity:0;transition:opacity 280ms ease;direction:" + (rtl ? "rtl" : "ltr");
+      inner.innerHTML =
+        (step ? '<div style="font-size:20px;letter-spacing:0.18em;text-transform:uppercase;color:#E8924A;font-family:system-ui,sans-serif;font-weight:700">' + step + '</div>' : '') +
+        '<h1 style="margin:0;font-size:58px;font-weight:500;letter-spacing:-0.01em;font-family:Georgia,serif">' + heading + '</h1>' +
+        '<div style="width:64px;height:2px;background:#E8924A;margin:8px auto 0;border-radius:2px"></div>' +
+        '<p style="margin:0;font-size:24px;color:rgba(236,228,216,0.6);font-family:system-ui,sans-serif">' + sub + '</p>';
+      const old = layer.firstElementChild;
+      if (old) { old.style.opacity = "0"; setTimeout(() => old.remove(), 300); }
+      layer.appendChild(inner);
+      layer.style.opacity = "1";
+      requestAnimationFrame(() => { inner.style.opacity = "1"; });
+      setTimeout(resolve, 340);
+    });
+    window.__qcvCardHide = () => new Promise((resolve) => {
+      const layer = document.getElementById("qcv-card");
+      if (!layer) { resolve(undefined); return; }
+      layer.style.opacity = "0";
+      setTimeout(() => { layer.replaceChildren(); resolve(undefined); }, 320);
+    });
+
+    // Lower-third caption — the tutorial narration during live scenes.
+    window.__qcvCaption = (text, rtl) => {
+      let cap = document.getElementById("qcv-caption");
+      if (!cap) {
+        cap = document.createElement("div");
+        cap.id = "qcv-caption";
+        cap.style.cssText = [
+          "position:fixed", "bottom:96px", "left:50%", "transform:translateX(-50%)",
+          "z-index:2147483645", "max-width:70vw", "padding:12px 22px",
+          "border-radius:999px", "background:rgba(8,14,17,0.85)",
+          "border:1px solid rgba(232,146,74,0.4)", "backdrop-filter:blur(8px)",
+          "color:#ECE4D8", "font-family:system-ui,sans-serif", "font-size:20px",
+          "text-align:center", "opacity:0", "transition:opacity 250ms ease",
+          "pointer-events:none", "white-space:nowrap",
+        ].join(";");
+        document.body.appendChild(cap);
+      }
+      cap.style.direction = rtl ? "rtl" : "ltr";
+      cap.textContent = text;
+      cap.style.opacity = "1";
+    };
+    window.__qcvCaptionHide = () => {
+      const cap = document.getElementById("qcv-caption");
+      if (cap) cap.style.opacity = "0";
+    };
+  })();
+`;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function glide(page: Page, x: number, y: number, ms = 380): Promise<void> {
+    await page.evaluate(
+        ([px, py, pms]) => (window as unknown as { __qcvGlide(x: number, y: number, ms: number): Promise<void> }).__qcvGlide(px, py, pms),
+        [x, y, ms] as [number, number, number]
+    );
+    await page.mouse.move(x, y);
+}
+
+async function glideToAndClick(page: Page, selector: string, ms = 380): Promise<void> {
+    await page.locator(selector).first().evaluate((el) => el.scrollIntoView({ behavior: "smooth", block: "center" }));
+    await sleep(450);
+    const box = await page.locator(selector).first().boundingBox();
+    if (!box) throw new Error(`No box for ${selector}`);
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await glide(page, cx, cy, ms);
+    await page.evaluate(() => (window as unknown as { __qcvPulse(): void }).__qcvPulse());
+    await page.mouse.click(cx, cy);
+}
+
+async function dragBy(page: Page, selector: string, dx: number, dy: number): Promise<void> {
+    const box = await page.locator(selector).first().boundingBox();
+    if (!box) throw new Error(`No box for ${selector}`);
+    const sx = box.x + box.width / 2;
+    const sy = box.y + box.height / 2;
+    await glide(page, sx, sy, 380);
+    await page.mouse.down();
+    const steps = 22;
+    for (let i = 1; i <= steps; i++) {
+        const t = i / steps;
+        const k = t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+        const cx = sx + dx * k;
+        const cy = sy + dy * k;
+        await page.evaluate(([px, py]) => (window as unknown as { __qcvGlide(x: number, y: number, ms: number): Promise<void> }).__qcvGlide(px, py, 16), [cx, cy] as [number, number]);
+        await page.mouse.move(cx, cy);
+        await sleep(18);
+    }
+    await page.mouse.up();
+}
+
+async function showCard(page: Page, slide: Slide, holdMs = 1800): Promise<void> {
+    await page.evaluate(
+        ([s, h, su, rtl]) => (window as unknown as { __qcvCardShow(s: string | null, h: string, su: string, rtl: boolean): Promise<void> }).__qcvCardShow(s || null, h, su, rtl as unknown as boolean),
+        [slide.step ?? "", slide.heading, slide.sub, RTL] as [string, string, string, boolean]
+    );
+    await sleep(holdMs);
+}
+
+async function hideCard(page: Page): Promise<void> {
+    await page.evaluate(() => (window as unknown as { __qcvCardHide(): Promise<void> }).__qcvCardHide());
+    await sleep(250);
+}
+
+async function caption(page: Page, text: string): Promise<void> {
+    await page.evaluate(
+        ([t, rtl]) => (window as unknown as { __qcvCaption(t: string, rtl: boolean): void }).__qcvCaption(t, rtl as unknown as boolean),
+        [text, RTL] as [string, boolean]
+    );
+}
+
+async function captionHide(page: Page): Promise<void> {
+    await page.evaluate(() => (window as unknown as { __qcvCaptionHide(): void }).__qcvCaptionHide());
+}
+
+async function run(): Promise<void> {
+    await fs.mkdir(OUT_DIR, { recursive: true });
+    const browser = await chromium
+        .launch({ headless: true })
+        .catch(() => chromium.launch({ headless: true, channel: "msedge" }));
+    const context = await browser.newContext({
+        viewport: { width: W, height: H },
+        recordVideo: { dir: OUT_DIR, size: { width: W, height: H } },
+        locale: RTL ? "ar" : "en",
+    });
+    await context.addCookies([
+        { name: "quran-corpus-theme", value: encodeURIComponent(JSON.stringify({ theme: "dark", colorThemeId: "teal-amber" })), url: BASE },
+        { name: "NEXT_LOCALE", value: LOCALE, url: BASE },
+    ]);
+    await context.addInitScript(() => {
+        window.localStorage.setItem("quran-corpus-onboarding", JSON.stringify({ version: "2", showOnStartup: false, completed: true }));
+        window.localStorage.setItem("quran-corpus-viz-intro", JSON.stringify({ dismissed: ["radial-sura", "root-network"] }));
+    });
+    await context.addInitScript(PAGE_HELPERS);
+
+    const page = await context.newPage();
+    const recordStart = Date.now();
+
+    // ── Warm-up UNDER the welcome card (recording gets trimmed to the point
+    // where the card is already up, so the app never leaks through). ──
+    await page.goto(`${BASE}/${LOCALE}?viz=radial-sura&surah=1`, { waitUntil: "domcontentloaded" }).catch(() => {});
+    await showCard(page, copy.welcome, 200); // mounted immediately; holds through warm-up
+    await page.waitForSelector('.status-bar-label[data-status="full"]', { timeout: CORPUS_READY_TIMEOUT_MS });
+    const trimSeconds = Math.max(0, (Date.now() - recordStart) / 1000 - 0.2);
+    console.log(`corpus ready — trimming first ${trimSeconds.toFixed(1)}s`);
+
+    // Welcome sequence (all crossfades — no app peek-through).
+    await sleep(2400);
+    await showCard(page, copy.ready, 2400);
+    await showCard(page, copy.s1, 2000);
+
+    // ── Scene 1: home search ──
+    await hideCard(page);
+    await glideToAndClick(page, ".brand-block", 500);
+    await page.waitForSelector(".mhome-search input", { timeout: 20_000 });
+    await sleep(700);
+    await caption(page, copy.cap.type);
+    const searchBox = await page.locator(".mhome-search input").first().boundingBox();
+    if (!searchBox) throw new Error("home search input not found");
+    await glide(page, searchBox.x + searchBox.width * 0.35, searchBox.y + searchBox.height / 2, 450);
+    await page.locator(".mhome-search input").first().click();
+    for (const ch of "رحم") {
+        await page.keyboard.type(ch);
+        await sleep(210);
+    }
+    await sleep(1400);
+    await caption(page, copy.cap.profile);
+    const strip = await page.locator(".mhome-strip").first().boundingBox();
+    if (strip) await glide(page, strip.x + strip.width * 0.35, strip.y + strip.height / 2, 450);
+    await sleep(1600);
+
+    // ── Scene 2: read it in context ──
+    await caption(page, copy.cap.cta);
+    await sleep(600);
+    await glideToAndClick(page, ".mhome-cta-p", 420);
+    await captionHide(page);
+    await showCard(page, copy.s2, 1900);
+    await hideCard(page);
+    await sleep(3200); // entry fit + highlight focus (corpus already full)
+
+    if ((await page.locator(".viz-zoom-btn").count()) === 0) {
+        await glideToAndClick(page, '[data-testid="journey-panel-toggle"]', 420);
+        await sleep(700);
+    }
+    await caption(page, copy.cap.zoom);
+    for (let i = 0; i < 3; i++) {
+        await glideToAndClick(page, ".viz-zoom-btn >> nth=0", 260);
+        await sleep(600);
+    }
+    await sleep(1600);
+    await captionHide(page);
+
+    // ── Scene 3: root network ──
+    await showCard(page, copy.s3, 1900);
+    await hideCard(page);
+    await glideToAndClick(page, '[data-testid="journey-root"]', 450);
+    await page.waitForSelector(".rn-node", { timeout: 30_000 });
+    await caption(page, copy.cap.network);
+    await sleep(3600);
+
+    let pillVisible = await page
+        .waitForSelector('[data-testid="root-network-focus-expand-pill"]', { timeout: 8_000 })
+        .then(() => true)
+        .catch(() => false);
+    if (!pillVisible) {
+        const rahm = page.locator('.rn-node[data-node-id="root-رحم"]');
+        if (await rahm.count()) {
+            await glideToAndClick(page, '.rn-node[data-node-id="root-رحم"]', 450);
+            pillVisible = await page
+                .waitForSelector('[data-testid="root-network-focus-expand-pill"]', { timeout: 8_000 })
+                .then(() => true)
+                .catch(() => false);
+        }
+    }
+    if (pillVisible) {
+        await caption(page, copy.cap.expand);
+        await glideToAndClick(page, '[data-testid="root-network-focus-expand-pill"]', 420);
+        await sleep(2800);
+    }
+
+    await caption(page, copy.cap.drag);
+    const node = await page.locator(".rn-node").first().boundingBox();
+    if (node) {
+        await dragBy(page, ".rn-node >> nth=0", 130, -90);
+        await sleep(1100);
+    }
+    await captionHide(page);
+
+    // ── Scene 4: inspect + track ──
+    await showCard(page, copy.s4, 1900);
+    await hideCard(page);
+    await caption(page, copy.cap.inspect);
+    const rahmNode = page.locator('.rn-node[data-node-id="root-رحم"]');
+    if (await rahmNode.count()) {
+        await glideToAndClick(page, '.rn-node[data-node-id="root-رحم"]', 450);
+    } else {
+        await glideToAndClick(page, ".rn-node >> nth=1", 450);
+    }
+    await sleep(2000);
+    const track = page.locator(".mi-btn-track").first();
+    if (await track.count()) {
+        await caption(page, copy.cap.track);
+        await glideToAndClick(page, ".mi-btn-track", 450);
+        await sleep(1400);
+    }
+    await captionHide(page);
+
+    // ── Closing ──
+    await showCard(page, copy.close, 2400);
+
+    await context.close();
+    const video = page.video();
+    if (video) {
+        const p = await video.path();
+        const webm = path.join(OUT_DIR, `intro-${LOCALE}.webm`);
+        await fs.rename(p, webm).catch(async () => {
+            await fs.copyFile(p, webm);
+        });
+        const ffmpeg = require("ffmpeg-static") as string;
+        const mp4 = path.join(OUT_DIR, `intro-${LOCALE}.mp4`);
+        execFileSync(ffmpeg, [
+            "-ss", trimSeconds.toFixed(2),
+            "-i", webm,
+            "-vf", "fps=30,format=yuv420p",
+            "-c:v", "libx264", "-crf", "18", "-preset", "slow",
+            "-movflags", "+faststart",
+            "-y", mp4,
+        ], { stdio: "pipe" });
+        console.log(`video: ${mp4}`);
+    }
+    await browser.close();
+}
+
+run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
Playwright-based capture harness for the guided intro video (en + ar): real app footage, in-page animated cursor, crossfading step cards, lower-third tutorial captions, corpus-warm-up trimming via ffmpeg-static, CFR 30fps 1080p mp4 output.

Media is deliberately NOT in the repo: `.ux-shots/` was already gitignored, and `*.webm`/`*.mp4` are now globally ignored. Final cuts get hosted outside git (decision pending: Vercel blob / external).

## Test plan
- [x] Both locales recorded end-to-end (exit 0), frames verified: no app flash between slides, "Full corpus ready" in every scene frame, RTL cards correct
- [x] `git ls-files` contains no media

🤖 Generated with [Claude Code](https://claude.com/claude-code)