### PR TITLE
Domain cutover to quranobservatory.org + recovered search index redesign

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,8 +12,8 @@
       "Bash(grep -r semantic /c/Users/AvArc/RiderProjects/Quran-corpus-visualizer --include=*.tsx --include=*.ts --exclude-dir=node_modules --exclude-dir=.next)",
       "Bash(grep -r \"OpenAI\\\\|embedding\\\\|OPENAI_API_KEY\" /c/Users/AvArc/RiderProjects/Quran-corpus-visualizer --include=*.md --include=*.ts --include=*.tsx --exclude-dir=node_modules --exclude-dir=.next)",
       "Bash(npm test:*)",
-      "WebFetch(domain:quran.pluragate.org)",
-      "Bash(curl -sI \"https://quran.pluragate.org/embed/root-network?surah=3&theme=dark\")",
+      "WebFetch(domain:quranobservatory.org)",
+      "Bash(curl -sI \"https://quranobservatory.org/embed/root-network?surah=3&theme=dark\")",
       "Bash(npx -y serve docs -p 3333 --no-clipboard)",
       "Bash(gh pr:*)",
       "Bash(gh repo:*)"

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Interactive exploration of Quranic linguistic structure, morphology, search, and
 [![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![CI](https://github.com/lAvArt/Quran-corpus-visualizer/actions/workflows/ci.yml/badge.svg)](https://github.com/lAvArt/Quran-corpus-visualizer/actions/workflows/ci.yml)
-[![Vercel](https://img.shields.io/badge/Deployed%20on-Vercel-black?logo=vercel)](https://quran.pluragate.org)
+[![Vercel](https://img.shields.io/badge/Deployed%20on-Vercel-black?logo=vercel)](https://quranobservatory.org)
 
-[Live Demo](https://quran.pluragate.org) | [Report Bug](https://github.com/lAvArt/Quran-corpus-visualizer/issues/new?template=bug_report.md) | [Request Feature](https://github.com/lAvArt/Quran-corpus-visualizer/issues/new?template=feature_request.md)
+[Live Demo](https://quranobservatory.org) | [Report Bug](https://github.com/lAvArt/Quran-corpus-visualizer/issues/new?template=bug_report.md) | [Request Feature](https://github.com/lAvArt/Quran-corpus-visualizer/issues/new?template=feature_request.md)
 
 </div>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ Report it by email to `info@pluragate.org` with:
 
 This policy covers:
 
-- the application at `quran.pluragate.org`
+- the application at `quranobservatory.org`
 - the source code in this repository
 - Supabase schema, RLS policies, and function exposure
 - deployed dependencies under this app's control

--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -23,7 +23,7 @@
   --viz-cat-makki: #0f766e;
   --viz-cat-madani: #b45309;
   --toolbar-bg: rgba(255, 255, 255, 0.85);
-  --footer-glass-bg: rgba(255, 255, 255, 0.56);
+  --footer-glass-bg: rgba(255, 255, 255, 0.92);
   --header-dock-height: 42px;
   --header-gap: 28px;
   --header-clearance: calc(var(--header-dock-height) + var(--header-gap));
@@ -3696,7 +3696,7 @@ button.site-footer-link {
   --accent-ink: #2a1606;
   --selection: #fbead2;
   --toolbar-bg: rgba(18, 28, 33, 0.85);
-  --footer-glass-bg: rgba(12, 20, 24, 0.56);
+  --footer-glass-bg: rgba(12, 20, 24, 0.94);
   color: var(--ink);
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,7 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://quran.pluragate.org"),
+  metadataBase: new URL("https://quranobservatory.org"),
 };
 
 export default async function AppLayout({ children }: Readonly<{ children: React.ReactNode }>) {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -98,7 +98,7 @@ export default async function OGImage() {
             display: "flex",
           }}
         >
-          quran.pluragate.org
+          quranobservatory.org
         </div>
       </div>
     ),

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -98,7 +98,7 @@ export default async function TwitterImage() {
             display: "flex",
           }}
         >
-          quran.pluragate.org
+          quranobservatory.org
         </div>
       </div>
     ),

--- a/components/embed/EmbedClient.tsx
+++ b/components/embed/EmbedClient.tsx
@@ -270,7 +270,7 @@ export default function EmbedClient({ vizMode, initialRoot, initialSurah, initia
 
         <a
           className="embed-watermark"
-          href="https://quran.pluragate.org"
+          href="https://quranobservatory.org"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/components/search/SearchWorkspace.tsx
+++ b/components/search/SearchWorkspace.tsx
@@ -38,6 +38,9 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
   const searchStatus = readDevSearchStatus() ?? "available";
   const [selectedToken, setSelectedToken] = useState<CorpusToken | null>(null);
   const [selectedRoot, setSelectedRoot] = useState<string | null>(null);
+  // Surah picked in the Corpus index — drives the surah dossier card and
+  // scopes the index's Root/Lemma tabs to that surah.
+  const [indexSurahId, setIndexSurahId] = useState<number | null>(null);
   const [hasTrackedShellRender, setHasTrackedShellRender] = useState(false);
   const search = useSearch({
     tokens: allTokens,
@@ -141,6 +144,57 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
         .slice(0, 6),
     };
   }, [allTokens, spotlightRoot]);
+
+  // Surah dossier: what a surah is MADE OF (its roots and lemmas) — shown
+  // when a surah is picked in the index and no root spotlight overrides it.
+  const surahInsight = useMemo(() => {
+    if (!indexSurahId) return null;
+    const meta = SURAH_NAMES[indexSurahId];
+    // No early return on empty tokens: while the corpus is still streaming,
+    // the dossier shows the surah's static metadata immediately and the
+    // counts/chips fill in as batches land (streaming-honesty rule).
+    const surahTokens = allTokens.filter((token) => token.sura === indexSurahId);
+
+    const rootCounts = new Map<string, number>();
+    const lemmaCounts = new Map<string, number>();
+    const ayahs = new Set<number>();
+    for (const token of surahTokens) {
+      if (token.root) rootCounts.set(token.root, (rootCounts.get(token.root) ?? 0) + 1);
+      if (token.lemma) lemmaCounts.set(token.lemma, (lemmaCounts.get(token.lemma) ?? 0) + 1);
+      ayahs.add(token.ayah);
+    }
+
+    return {
+      surahId: indexSurahId,
+      name: meta?.name ?? `Surah ${indexSurahId}`,
+      arabic: meta?.arabic ?? "",
+      verses: meta?.verses ?? ayahs.size,
+      tokenCount: surahTokens.length,
+      rootCount: rootCounts.size,
+      lemmaCount: lemmaCounts.size,
+      topRoots: [...rootCounts.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .slice(0, 12),
+      topLemmas: [...lemmaCounts.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .slice(0, 12),
+    };
+  }, [allTokens, indexSurahId]);
+
+  // Shared by the index's Root tab AND the surah dossier's root chips:
+  // filter to the root and spotlight its corpus-wide dossier.
+  const handleIndexRootSelect = (root: string) => {
+    const token =
+      allTokens.find((entry) => normalizeRootFamily(entry.root) === normalizeRootFamily(root)) ?? null;
+    search.setQuery("");
+    search.setFilterLemma("");
+    search.setFilterPos("");
+    search.setFilterAyah("");
+    search.setFilterRoot(root);
+    search.setFiltersExpanded(true);
+    setSelectedToken(token);
+    setSelectedRoot(root);
+  };
 
   const resultBuckets = useMemo(
     () =>
@@ -355,6 +409,69 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
               <p className="workspace-search-hint">{t("searchPrimerHint")}</p>
             )}
 
+            {!rootInsight && surahInsight ? (
+              <article className="workspace-root-card" data-testid="search-surah-dossier">
+                <div className="workspace-root-head">
+                  <div>
+                    <p className="ui-kicker">{t("surahInsight.title")}</p>
+                    <h3 className="workspace-root-title">
+                      {surahInsight.surahId}. {surahInsight.name}
+                    </h3>
+                    <p className="workspace-root-gloss" lang="ar" dir="rtl">{surahInsight.arabic}</p>
+                  </div>
+                </div>
+
+                <div className="workspace-root-metrics">
+                  <div className="workspace-root-metric">
+                    <span>{t("surahInsight.verses")}</span>
+                    <strong>{surahInsight.verses.toLocaleString()}</strong>
+                  </div>
+                  <div className="workspace-root-metric">
+                    <span>{t("surahInsight.words")}</span>
+                    <strong>{surahInsight.tokenCount.toLocaleString()}</strong>
+                  </div>
+                  <div className="workspace-root-metric">
+                    <span>{t("surahInsight.roots")}</span>
+                    <strong>{surahInsight.rootCount.toLocaleString()}</strong>
+                  </div>
+                  <div className="workspace-root-metric">
+                    <span>{t("surahInsight.lemmas")}</span>
+                    <strong>{surahInsight.lemmaCount.toLocaleString()}</strong>
+                  </div>
+                </div>
+
+                <div className="workspace-root-section">
+                  <span className="workspace-root-section-label">{t("surahInsight.topRoots")}</span>
+                  <div className="workspace-tag-row">
+                    {surahInsight.topRoots.map(([root, count]) => (
+                      <button
+                        key={root}
+                        type="button"
+                        className="workspace-tag workspace-tag-button"
+                        onClick={() => handleIndexRootSelect(root)}
+                        title={t("surahInsight.rootChipHint")}
+                      >
+                        <span lang="ar" dir="rtl">{root}</span>
+                        <em>{count}</em>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="workspace-root-section">
+                  <span className="workspace-root-section-label">{t("surahInsight.topLemmas")}</span>
+                  <div className="workspace-tag-row">
+                    {surahInsight.topLemmas.map(([lemma, count]) => (
+                      <span key={lemma} className="workspace-tag">
+                        <span lang="ar" dir="rtl">{lemma}</span>
+                        <em>{count}</em>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </article>
+            ) : null}
+
             {rootInsight ? (
               <article className="workspace-root-card">
                 <div className="workspace-root-head">
@@ -497,23 +614,16 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
           </div>
           <CorpusIndex
             tokens={allTokens}
+            selectedSurahId={indexSurahId ?? undefined}
+            onClearSurah={() => setIndexSurahId(null)}
             onSelectSurah={(surahId) => {
-              const token = allTokens.find((entry) => entry.sura === surahId) ?? null;
-              setSelectedToken(token);
-              setSelectedRoot(token?.root ?? null);
+              // A surah pick opens the SURAH dossier (what the surah is made
+              // of) — it must never spotlight some arbitrary token's root.
+              setIndexSurahId(surahId);
+              setSelectedToken(null);
+              setSelectedRoot(null);
             }}
-            onSelectRoot={(root) => {
-              const token =
-                allTokens.find((entry) => normalizeRootFamily(entry.root) === normalizeRootFamily(root)) ?? null;
-              search.setQuery("");
-              search.setFilterLemma("");
-              search.setFilterPos("");
-              search.setFilterAyah("");
-              search.setFilterRoot(root);
-              search.setFiltersExpanded(true);
-              setSelectedToken(token);
-              setSelectedRoot(root);
-            }}
+            onSelectRoot={handleIndexRootSelect}
             onSelectLemma={(lemma) => {
               const token = allTokens.find((entry) => entry.lemma === lemma) ?? null;
               search.setQuery("");
@@ -580,10 +690,9 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
 
         .workspace-command-bar :global(.search-input-wrapper) {
           padding: 0.75rem 0.85rem;
-          border-radius: 18px;
-          background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(248, 244, 238, 0.9));
-          border-color: color-mix(in srgb, var(--accent), white 36%);
-          box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+          border-radius: 14px;
+          background: var(--ui-surface);
+          border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
         }
 
         .workspace-command-bar :global(.search-input) {
@@ -619,9 +728,26 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
         .workspace-snapshot-card,
         .workspace-root-card {
           padding: 1rem;
-          border: 1px solid rgba(17, 24, 39, 0.08);
-          border-radius: 20px;
-          background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(249, 245, 239, 0.82));
+          border: 1px solid var(--line);
+          border-radius: 14px;
+          background: var(--ui-surface-soft);
+        }
+
+        .workspace-tag-button {
+          cursor: pointer;
+          font-family: inherit;
+          transition: border-color 0.15s ease, color 0.15s ease;
+        }
+
+        .workspace-tag-button:hover {
+          border-color: var(--accent);
+          color: var(--ink);
+        }
+
+        .workspace-tag em {
+          font-style: normal;
+          color: var(--ink-muted);
+          font-variant-numeric: tabular-nums;
         }
 
         .workspace-snapshot-card {
@@ -691,10 +817,8 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
         .workspace-root-card {
           display: grid;
           gap: 1rem;
-          border-color: color-mix(in srgb, var(--accent), white 68%);
-          background:
-            radial-gradient(circle at top right, rgba(249, 115, 22, 0.12), transparent 32%),
-            linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(248, 244, 238, 0.82));
+          border-color: color-mix(in srgb, var(--accent) 24%, var(--line));
+          background: var(--ui-surface-soft);
         }
 
         .workspace-root-head {
@@ -821,21 +945,21 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
           }
         }
 
+        /* Flat token surfaces — the old navy linear-gradients + gold radial
+           tints were the last visible remnant of the pre-observatory theme. */
         :global([data-theme="dark"] .workspace-command-bar .search-input-wrapper) {
-          background: linear-gradient(180deg, rgba(22, 28, 35, 0.94), rgba(16, 20, 27, 0.92));
+          background: var(--panel);
         }
 
         :global([data-theme="dark"] .workspace-command-bar .search-advanced-filters),
         :global([data-theme="dark"] .workspace-command-bar .search-results-dropdown) {
-          background: rgba(16, 20, 27, 0.94);
+          background: var(--panel);
         }
 
         :global([data-theme="dark"] .workspace-snapshot-card),
         :global([data-theme="dark"] .workspace-root-card) {
-          background:
-            radial-gradient(circle at top right, rgba(249, 115, 22, 0.12), transparent 32%),
-            linear-gradient(180deg, rgba(22, 28, 35, 0.9), rgba(16, 20, 27, 0.9));
-          border-color: rgba(255, 255, 255, 0.08);
+          background: color-mix(in srgb, var(--panel) 94%, transparent);
+          border-color: var(--line);
         }
 
         :global([data-theme="dark"] .workspace-root-metric),

--- a/components/ui/CorpusIndex.tsx
+++ b/components/ui/CorpusIndex.tsx
@@ -11,9 +11,13 @@ interface CorpusIndexProps {
     onSelectSurah: (id: number) => void;
     onSelectRoot: (root: string) => void;
     onSelectLemma: (lemma: string) => void;
+    /** Un-scope the Root/Lemma tabs back to the whole corpus. */
+    onClearSurah?: () => void;
     className?: string;
     selectedSurahId?: number;
 }
+
+const PAGE_SIZE = 25;
 
 type TabMode = "surah" | "root" | "lemma";
 
@@ -24,12 +28,14 @@ export default function CorpusIndex({
     onSelectSurah,
     onSelectRoot,
     onSelectLemma,
+    onClearSurah,
     className = "",
     selectedSurahId,
 }: CorpusIndexProps) {
     const t = useTranslations('CorpusIndex');
     const [activeTab, setActiveTab] = useState<TabMode>("surah");
     const [searchQuery, setSearchQuery] = useState("");
+    const [page, setPage] = useState(0);
 
     // Compute aggregates
     const data = useMemo(() => {
@@ -113,6 +119,19 @@ export default function CorpusIndex({
         }
     }, [activeTab, searchQuery, data, t]);
 
+    // Pagination is derived, never stored: reset to the first page whenever
+    // the underlying list changes shape (tab, filter, or scope switch).
+    const pageCount = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE));
+    const safePage = Math.min(page, pageCount - 1);
+    const pagedItems = filteredItems.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+
+    const switchTab = (mode: TabMode) => {
+        setActiveTab(mode);
+        setPage(0);
+    };
+
+    const scopedSurahName = selectedSurahId ? SURAH_NAMES[selectedSurahId]?.name ?? `#${selectedSurahId}` : null;
+
     return (
         <div className={`corpus-index ${className}`}>
             <div className="index-tabs" role="tablist" aria-label={t('tabsAriaLabel')}>
@@ -121,7 +140,7 @@ export default function CorpusIndex({
                         key={mode}
                         className={`index-tab-btn ${activeTab === mode ? "active" : ""}`}
                         data-testid={`index-tab-${mode}`}
-                        onClick={() => setActiveTab(mode)}
+                        onClick={() => switchTab(mode)}
                         role="tab"
                         aria-selected={activeTab === mode}
                         id={`index-tab-${mode}`}
@@ -131,6 +150,19 @@ export default function CorpusIndex({
                     </button>
                 ))}
             </div>
+
+            {activeTab !== "surah" && scopedSurahName ? (
+                <div className="index-scope-row">
+                    <span className="index-scope-chip" data-testid="index-scope-chip">
+                        {t('scopedTo', { name: scopedSurahName })}
+                    </span>
+                    {onClearSurah ? (
+                        <button type="button" className="index-scope-clear" onClick={() => { onClearSurah(); setPage(0); }}>
+                            {t('clearScope')}
+                        </button>
+                    ) : null}
+                </div>
+            ) : null}
 
             <div className="search-container">
                 <svg className="search-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -142,12 +174,12 @@ export default function CorpusIndex({
                     data-testid="index-search-input"
                     placeholder={t('searchPlaceholder')}
                     value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onChange={(e) => { setSearchQuery(e.target.value); setPage(0); }}
                     aria-label={t('searchPlaceholder')}
                 />
             </div>
             <div className="index-list custom-scrollbar" role="tabpanel" id="index-tabpanel" aria-labelledby={`index-tab-${activeTab}`}>
-                {filteredItems.map((item) => (
+                {pagedItems.map((item) => (
                     <button
                         key={item.id}
                         data-testid={`index-item-${String(item.id)}`}
@@ -182,6 +214,111 @@ export default function CorpusIndex({
                 }
             </div >
 
+            {pageCount > 1 ? (
+                <div className="index-pager" data-testid="index-pager">
+                    <button
+                        type="button"
+                        className="index-pager-btn"
+                        onClick={() => setPage(Math.max(0, safePage - 1))}
+                        disabled={safePage === 0}
+                        aria-label={t('prevPage')}
+                    >
+                        ‹
+                    </button>
+                    <span className="index-pager-status">
+                        {t('pageStatus', {
+                            from: safePage * PAGE_SIZE + 1,
+                            to: Math.min(filteredItems.length, (safePage + 1) * PAGE_SIZE),
+                            total: filteredItems.length,
+                        })}
+                    </span>
+                    <button
+                        type="button"
+                        className="index-pager-btn"
+                        onClick={() => setPage(Math.min(pageCount - 1, safePage + 1))}
+                        disabled={safePage >= pageCount - 1}
+                        aria-label={t('nextPage')}
+                    >
+                        ›
+                    </button>
+                </div>
+            ) : null}
+
+            <style jsx>{`
+                .index-scope-row {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    margin-bottom: 8px;
+                }
+
+                .index-scope-chip {
+                    font-size: 0.72rem;
+                    color: var(--ink-secondary);
+                    border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+                    background: color-mix(in srgb, var(--accent) 10%, transparent);
+                    border-radius: 999px;
+                    padding: 3px 10px;
+                }
+
+                .index-scope-clear {
+                    font-size: 0.72rem;
+                    color: var(--ink-muted);
+                    background: none;
+                    border: none;
+                    cursor: pointer;
+                    text-decoration: underline;
+                    font-family: inherit;
+                }
+
+                .index-scope-clear:hover {
+                    color: var(--ink);
+                }
+
+                /* Bounded list: pagination keeps pages short, the cap keeps the
+                   worst case (long labels wrapping) from crawling under the
+                   fixed footer. */
+                .index-list {
+                    max-height: 520px;
+                    overflow-y: auto;
+                }
+
+                .index-pager {
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    gap: 14px;
+                    padding-top: 10px;
+                }
+
+                .index-pager-btn {
+                    width: 30px;
+                    height: 30px;
+                    border-radius: 8px;
+                    border: 1px solid var(--line);
+                    background: transparent;
+                    color: var(--ink-secondary);
+                    font-size: 1rem;
+                    line-height: 1;
+                    cursor: pointer;
+                }
+
+                .index-pager-btn:hover:not(:disabled) {
+                    border-color: var(--accent);
+                    color: var(--ink);
+                }
+
+                .index-pager-btn:disabled {
+                    opacity: 0.35;
+                    cursor: default;
+                }
+
+                .index-pager-status {
+                    font-size: 0.72rem;
+                    color: var(--ink-muted);
+                    font-variant-numeric: tabular-nums;
+                }
+            `}</style>
         </div >
     );
 }

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -6,7 +6,7 @@ Quran Corpus Visualizer supports embedding individual visualizations in external
 
 ```html
 <iframe
-  src="https://quran.pluragate.org/embed/root-network?surah=3&theme=dark"
+  src="https://quranobservatory.org/embed/root-network?surah=3&theme=dark"
   width="800"
   height="600"
   style="border:0;border-radius:8px"
@@ -18,7 +18,7 @@ Quran Corpus Visualizer supports embedding individual visualizations in external
 ## URL Format
 
 ```
-https://quran.pluragate.org/embed/{vizMode}?surah={number}&theme={light|dark}&root={root}
+https://quranobservatory.org/embed/{vizMode}?surah={number}&theme={light|dark}&root={root}
 ```
 
 ## Available Visualization Modes
@@ -50,7 +50,7 @@ https://quran.pluragate.org/embed/{vizMode}?surah={number}&theme={light|dark}&ro
 
 ```html
 <iframe
-  src="https://quran.pluragate.org/embed/root-network?surah=3&theme=dark"
+  src="https://quranobservatory.org/embed/root-network?surah=3&theme=dark"
   width="800"
   height="600"
   style="border:0;border-radius:8px"
@@ -63,7 +63,7 @@ https://quran.pluragate.org/embed/{vizMode}?surah={number}&theme={light|dark}&ro
 
 ```html
 <iframe
-  src="https://quran.pluragate.org/embed/radial-sura?surah=36&theme=light"
+  src="https://quranobservatory.org/embed/radial-sura?surah=36&theme=light"
   width="800"
   height="600"
   style="border:0;border-radius:8px"
@@ -76,7 +76,7 @@ https://quran.pluragate.org/embed/{vizMode}?surah={number}&theme={light|dark}&ro
 
 ```html
 <iframe
-  src="https://quran.pluragate.org/embed/sankey-flow?surah=2&theme=dark"
+  src="https://quranobservatory.org/embed/sankey-flow?surah=2&theme=dark"
   width="800"
   height="600"
   style="border:0;border-radius:8px"
@@ -92,7 +92,7 @@ For responsive layouts, wrap the iframe in a container:
 ```html
 <div style="position:relative;width:100%;padding-bottom:75%;overflow:hidden">
   <iframe
-    src="https://quran.pluragate.org/embed/root-network?surah=3&theme=dark"
+    src="https://quranobservatory.org/embed/root-network?surah=3&theme=dark"
     style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;border-radius:8px"
     loading="lazy"
     allowfullscreen

--- a/lib/seo/site.ts
+++ b/lib/seo/site.ts
@@ -1,11 +1,11 @@
 /**
  * Single source of truth for the public site origin, used by metadata,
  * sitemap, robots, and JSON-LD. Reads NEXT_PUBLIC_SITE_URL so the domain
- * cutover (quran.pluragate.org → quranobservatory.org) is one env change,
+ * cutover (quranobservatory.org → quranobservatory.org) is one env change,
  * not a repo-wide sweep.
  */
 export const SITE_URL = (
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://quran.pluragate.org"
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://quranobservatory.org"
 ).replace(/\/$/, "");
 
 export const SITE_NAME = "Quran Corpus Visualizer";

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -132,7 +132,7 @@
     "Index": {
         "title": "مرئيات المدونة القرآنية",
         "eyebrow": "مرصد اللسانيات القرآنية",
-        "brand": "quran.pluragate.org",
+        "brand": "quranobservatory.org",
         "hideTools": "إخفاء الأدوات",
         "showTools": "عرض الأدوات",
         "dataStatus": {

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -227,6 +227,16 @@
             "title": "بطاقة الجذر",
             "topLemmas": "أكثر الجذوع",
             "posMix": "مزيج الأنواع"
+        },
+        "surahInsight": {
+            "title": "بطاقة السورة",
+            "verses": "آيات",
+            "words": "كلمات",
+            "roots": "جذور مميزة",
+            "lemmas": "أبنية مميزة",
+            "topRoots": "أكثر الجذور في هذه السورة",
+            "topLemmas": "أكثر الأبنية في هذه السورة",
+            "rootChipHint": "افتح بطاقة هذا الجذر على مستوى المدونة"
         }
     },
     "AppSidebar": {
@@ -366,7 +376,12 @@
         "searchPlaceholder": "تصفية...",
         "verses": "آيات",
         "noResults": "لم توجد نتائج",
-        "tabsAriaLabel": "فئات الفهرس"
+        "tabsAriaLabel": "فئات الفهرس",
+        "scopedTo": "في {name}",
+        "clearScope": "كل السور",
+        "pageStatus": "{from}–{to} من {total}",
+        "prevPage": "الصفحة السابقة",
+        "nextPage": "الصفحة التالية"
     },
     "CurrentSelectionPanel": {
         "title": "التحديد الحالي",

--- a/messages/en.json
+++ b/messages/en.json
@@ -227,6 +227,16 @@
             "title": "Root dossier",
             "topLemmas": "Frequent lemmas",
             "posMix": "POS mix"
+        },
+        "surahInsight": {
+            "title": "Surah dossier",
+            "verses": "verses",
+            "words": "words",
+            "roots": "distinct roots",
+            "lemmas": "distinct lemmas",
+            "topRoots": "Top roots in this surah",
+            "topLemmas": "Top lemmas in this surah",
+            "rootChipHint": "Open this root's corpus-wide dossier"
         }
     },
     "AppSidebar": {
@@ -364,7 +374,12 @@
         "searchPlaceholder": "Filter...",
         "verses": "verses",
         "noResults": "No results found",
-        "tabsAriaLabel": "Index categories"
+        "tabsAriaLabel": "Index categories",
+        "scopedTo": "in {name}",
+        "clearScope": "All surahs",
+        "pageStatus": "{from}–{to} of {total}",
+        "prevPage": "Previous page",
+        "nextPage": "Next page"
     },
     "CurrentSelectionPanel": {
         "title": "Current Selection",

--- a/messages/en.json
+++ b/messages/en.json
@@ -132,7 +132,7 @@
     "Index": {
         "title": "Quran Corpus Visualizer",
         "eyebrow": "Quranic Linguistics Observatory",
-        "brand": "quran.pluragate.org",
+        "brand": "quranobservatory.org",
         "hideTools": "Hide Tools",
         "showTools": "Show Tools",
         "dataStatus": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Interactive exploration of Quranic linguistic structure and morphology through dynamic visualizations",
   "license": "GPL-3.0",
   "private": false,
-  "homepage": "https://quran.pluragate.org",
+  "homepage": "https://quranobservatory.org",
   "repository": {
     "type": "git",
     "url": "https://github.com/lAvArt/Quran-corpus-visualizer.git"

--- a/scripts/push-email-templates.ts
+++ b/scripts/push-email-templates.ts
@@ -62,8 +62,8 @@ async function pushTemplates() {
     console.log(`\n📧  Pushing email templates to Supabase project: ${projectRef}\n`);
 
     // Fix site_url to production first
-    await patchAuth('site_url → https://quran.pluragate.org', {
-        site_url: 'https://quran.pluragate.org',
+    await patchAuth('site_url → https://quranobservatory.org', {
+        site_url: 'https://quranobservatory.org',
     });
 
     // Push subjects


### PR DESCRIPTION
## Two commits

### 1. Recovered: search index redesign (missed #44's merge window — same race as #40/#41/#42)
- Surah click → **Surah dossier** (verses/words/distinct roots/lemmas, clickable top-root chips → corpus-wide root dossier); previously it spotlighted the surah's first token's root.
- Root/Lemma tabs scope to the selected surah ("in {surah}" chip + "All surahs" clear); **paginated** (25/page) + height-capped lists.
- Legacy gradients flattened; footer glass near-opaque.

### 2. Domain cutover
Sweeps every `quran.pluragate.org` reference to **quranobservatory.org**: SEO fallback origin, `Index.brand` (en+ar), package.json homepage, README, SECURITY.md, EMBEDDING.md, OG/Twitter copy, embed client, Supabase email-template `site_url`, local tooling allowlist. Emails/handle/copyright stay Pluragate (org identity).

## Post-merge checklist
- [ ] `npm run db:email-templates` (auth emails pick up the new origin)
- [ ] Google Search Console: add `quranobservatory.org` property, submit `/sitemap.xml`
- [ ] Supabase Auth → URL Configuration: Site URL → `https://quranobservatory.org` (redirect allowlist already discussed)

## Test plan
- [x] lint / typecheck / 181 tests / i18n sync
- [x] Only org-identity `pluragate` references remain (emails, @handle, ©)

🤖 Generated with [Claude Code](https://claude.com/claude-code)