### PR TITLE
fix(auth): Google sign-in callback was localized into a 404

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -14,8 +14,13 @@ export async function GET(request: NextRequest) {
         const supabase = await createClient();
         const { error } = await supabase.auth.exchangeCodeForSession(code);
         if (!error) {
-            // Redirect to `next` (e.g. /update-password or home)
-            const redirectPath = next.startsWith("/") ? next : `/${next}`;
+            // `next=update-password` must land on the auth-scoped page
+            // (/auth/update-password → middleware adds the locale); a bare
+            // /update-password localizes to a nonexistent route.
+            const redirectPath =
+                next === "update-password"
+                    ? "/auth/update-password"
+                    : next.startsWith("/") ? next : `/${next}`;
             return NextResponse.redirect(`${origin}${redirectPath}`);
         }
     }

--- a/proxy.ts
+++ b/proxy.ts
@@ -77,6 +77,10 @@ export const config = {
     // and static public assets. NOTE: data files like the QAC morphology .txt
     // MUST be excluded here — otherwise the locale prefix (/en/data/…) 404s the
     // fetch and the corpus loses all roots/POS (no coloured bars / arcs).
-    "/((?!api|trpc|embed|data|_next/static|_next/image|favicon.ico|manifest.webmanifest|robots.txt|sitemap.xml|opengraph-image|twitter-image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|txt|json|csv|woff2?)$).*)",
+    // auth/callback is the locale-LESS Supabase OAuth/email callback (a route
+    // handler, not a page): localizing it 307'd /auth/callback?code=… to a
+    // nonexistent /{locale}/auth/callback and dropped the one-time code —
+    // Google sign-in could never complete.
+    "/((?!api|trpc|embed|data|auth/callback|_next/static|_next/image|favicon.ico|manifest.webmanifest|robots.txt|sitemap.xml|opengraph-image|twitter-image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|txt|json|csv|woff2?)$).*)",
   ],
 };


### PR DESCRIPTION
The middleware localized the locale-LESS /auth/callback route handler: /auth/callback?code=… 307'd to a nonexistent /{locale}/auth/callback, 404ing AND dropping the one-time OAuth code — Google sign-in could never complete, and email-confirmation links suffered the same fate. auth/callback is now excluded from the proxy matcher (both the i18n handling and the geo first-visit redirect).

Also fixes the password-reset continuation: next=update-password now lands on /auth/update-password (the real, locale-prefixed page) instead of a bare /update-password that localized to nothing.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Screenshots / GIFs

If applicable, add screenshots or GIFs showing the change.

## Checklist

- [ ] My code follows the project's coding conventions
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass (`npm run test`)
- [ ] Linting passes (`npm run lint`)
- [ ] Type checking passes (`npm run typecheck`)
- [ ] I have updated documentation where needed
- [ ] My changes align with the [Roadmap](docs/ROADMAP.md)

## Additional Notes

Any additional context or implementation details reviewers should know.
