### PR TITLE
Profile identity hero + corpus-index overflow/pager + full surah distribution

### DIFF
--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -6357,8 +6357,10 @@ button.site-footer-link {
 .corpus-index {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  background: var(--panel);
+  /* No own height/background: the parent card supplies the surface — the
+     old height:100% + --panel fill painted a dark slab past the card's
+     rounded boundary (visible overflow on the search page). */
+  min-height: 0;
   font-family: var(--font-sans);
 }
 

--- a/components/search/SearchWorkspace.tsx
+++ b/components/search/SearchWorkspace.tsx
@@ -41,6 +41,9 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
   // Surah picked in the Corpus index — drives the surah dossier card and
   // scopes the index's Root/Lemma tabs to that surah.
   const [indexSurahId, setIndexSurahId] = useState<number | null>(null);
+  // Root dossier surah list: collapsed to the top 6 by default, expandable
+  // to the full distribution; re-collapses when the spotlighted root changes.
+  const [showAllSurahs, setShowAllSurahs] = useState(false);
   const [hasTrackedShellRender, setHasTrackedShellRender] = useState(false);
   const search = useSearch({
     tokens: allTokens,
@@ -83,6 +86,10 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
     if (search.queryIntent === "arabic-root" && search.query.trim()) return search.query.trim();
     return search.results.find((result) => result.matchedRoot?.trim())?.matchedRoot?.trim() ?? "";
   }, [parsedQuery.root, search.filterRoot, search.query, search.queryIntent, search.results, selectedRoot]);
+
+  useEffect(() => {
+    setShowAllSurahs(false);
+  }, [spotlightRoot]);
 
   const rootInsight = useMemo(() => {
     if (!spotlightRoot) return null;
@@ -140,8 +147,7 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
           occurrences: value.occurrences,
           ayahCount: value.ayahs.size,
         }))
-        .sort((a, b) => b.occurrences - a.occurrences || a.surahId - b.surahId)
-        .slice(0, 6),
+        .sort((a, b) => b.occurrences - a.occurrences || a.surahId - b.surahId),
     };
   }, [allTokens, spotlightRoot]);
 
@@ -546,7 +552,7 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
                 <div className="workspace-root-section">
                   <span className="workspace-root-section-label">{tSemantic("rootInfo.surahDistribution")}</span>
                   <div className="workspace-surah-list">
-                    {rootInsight.topSurahs.map((surah) => {
+                    {(showAllSurahs ? rootInsight.topSurahs : rootInsight.topSurahs.slice(0, 6)).map((surah) => {
                       const maxOccurrences = rootInsight.topSurahs[0]?.occurrences ?? 1;
                       const width = Math.max(10, (surah.occurrences / maxOccurrences) * 100);
                       return (
@@ -567,6 +573,18 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
                       );
                     })}
                   </div>
+                  {rootInsight.topSurahs.length > 6 ? (
+                    <button
+                      type="button"
+                      className="workspace-surah-toggle"
+                      data-testid="root-dossier-surah-toggle"
+                      onClick={() => setShowAllSurahs((v) => !v)}
+                    >
+                      {showAllSurahs
+                        ? t("surahListCollapse")
+                        : t("surahListExpand", { count: rootInsight.topSurahs.length })}
+                    </button>
+                  ) : null}
                 </div>
               </article>
             ) : null}
@@ -731,6 +749,25 @@ export default function SearchWorkspace({ initialCorpusData }: SearchWorkspacePr
           border: 1px solid var(--line);
           border-radius: 14px;
           background: var(--ui-surface-soft);
+        }
+
+        .workspace-surah-toggle {
+          margin-top: 0.6rem;
+          border: 1px solid var(--line);
+          background: transparent;
+          color: var(--ink-secondary);
+          font-family: inherit;
+          font-size: 0.75rem;
+          font-weight: 600;
+          padding: 6px 14px;
+          border-radius: 999px;
+          cursor: pointer;
+          transition: border-color 0.15s ease, color 0.15s ease;
+        }
+
+        .workspace-surah-toggle:hover {
+          border-color: var(--accent);
+          color: var(--ink);
         }
 
         .workspace-tag-button {

--- a/components/study/StudyHub.tsx
+++ b/components/study/StudyHub.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState, type ChangeEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/routing";
 import { useAuth } from "@/lib/context/AuthContext";
@@ -52,6 +52,11 @@ export default function StudyHub({ showBackLink = false, title }: StudyHubProps)
     : (user?.email ?? "?").split("@")[0].slice(0, 2)
   ).toUpperCase();
   const [displayNameDraft, setDisplayNameDraft] = useState(currentDisplayName);
+  // Auth hydrates after mount — adopt the stored name once it arrives (and
+  // after saves, when the canonical value catches up to the draft).
+  useEffect(() => {
+    setDisplayNameDraft(currentDisplayName);
+  }, [currentDisplayName]);
   const [savingProfile, setSavingProfile] = useState(false);
   const [profileSavedFlash, setProfileSavedFlash] = useState(false);
 
@@ -143,7 +148,7 @@ export default function StudyHub({ showBackLink = false, title }: StudyHubProps)
     <AppWorkspaceShell
       kicker={t("studyKicker")}
       title={title ?? t("title")}
-      description={user ? user.email ?? "" : t("guestMode")}
+      description={user ? "" : t("guestMode")}
       panelWidth="wide"
       backgroundVariant="study"
       status={
@@ -164,6 +169,50 @@ export default function StudyHub({ showBackLink = false, title }: StudyHubProps)
             {tAuth("signIn")}
           </button>
         </div>
+      ) : null}
+
+      {user ? (
+        <section className="ui-card ui-section-card study-identity-card study-identity-hero" data-testid="profile-identity-card">
+          <div className="study-identity-row">
+            <span className="study-identity-avatar" aria-hidden="true">
+              {avatarUrl ? (
+                /* remote avatar hosts (Google) aren't in next/image's allowlist */
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={avatarUrl} alt="" referrerPolicy="no-referrer" />
+              ) : (
+                identityInitials
+              )}
+            </span>
+            <div className="study-identity-fields">
+              <label className="ui-field">
+                <span>{t("displayNameLabel")}</span>
+                <div className="study-identity-name-row">
+                  <input
+                    type="text"
+                    className="ui-input"
+                    value={displayNameDraft}
+                    placeholder={t("displayNamePlaceholder")}
+                    maxLength={60}
+                    onChange={(event) => setDisplayNameDraft(event.target.value)}
+                  />
+                  <button
+                    type="button"
+                    className="ui-btn ui-btn-primary"
+                    disabled={savingProfile || displayNameDraft.trim() === currentDisplayName}
+                    onClick={() => void handleSaveDisplayName()}
+                  >
+                    {savingProfile ? t("savingProfile") : t("saveProfile")}
+                  </button>
+                </div>
+              </label>
+              <p className="study-identity-meta">
+                {user.email}
+                {profileSavedFlash ? <span className="study-identity-saved"> · {t("profileSaved")}</span> : null}
+              </p>
+              <p className="study-identity-hint">{t("avatarHint")}</p>
+            </div>
+          </div>
+        </section>
       ) : null}
 
       {pendingMigration ? (
@@ -462,49 +511,6 @@ export default function StudyHub({ showBackLink = false, title }: StudyHubProps)
 
       {activePanel === "account" ? (
         <section className="study-panel-page section-spacer">
-          {user ? (
-            <section className="ui-card ui-section-card study-identity-card" data-testid="profile-identity-card">
-              <div className="study-identity-row">
-                <span className="study-identity-avatar" aria-hidden="true">
-                  {avatarUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element -- remote avatar hosts (Google) aren't allowlisted for next/image
-                    <img src={avatarUrl} alt="" referrerPolicy="no-referrer" />
-                  ) : (
-                    identityInitials
-                  )}
-                </span>
-                <div className="study-identity-fields">
-                  <label className="ui-field">
-                    <span>{t("displayNameLabel")}</span>
-                    <div className="study-identity-name-row">
-                      <input
-                        type="text"
-                        className="ui-input"
-                        value={displayNameDraft}
-                        placeholder={t("displayNamePlaceholder")}
-                        maxLength={60}
-                        onChange={(event) => setDisplayNameDraft(event.target.value)}
-                      />
-                      <button
-                        type="button"
-                        className="ui-btn ui-btn-primary"
-                        disabled={savingProfile || displayNameDraft.trim() === currentDisplayName}
-                        onClick={() => void handleSaveDisplayName()}
-                      >
-                        {savingProfile ? t("savingProfile") : t("saveProfile")}
-                      </button>
-                    </div>
-                  </label>
-                  <p className="study-identity-meta">
-                    {user.email}
-                    {profileSavedFlash ? <span className="study-identity-saved"> · {t("profileSaved")}</span> : null}
-                  </p>
-                  <p className="study-identity-hint">{t("avatarHint")}</p>
-                </div>
-              </div>
-            </section>
-          ) : null}
-
           <section className="ui-grid-two-wide">
             <section className="ui-card ui-section-card study-tools-card">
               <div className="ui-card-head">
@@ -567,6 +573,18 @@ export default function StudyHub({ showBackLink = false, title }: StudyHubProps)
       <style jsx>{`
         .study-identity-card {
           margin-bottom: 1rem;
+        }
+
+        /* Hero placement: identity leads the page, study panels follow. */
+        .study-identity-hero .study-identity-avatar {
+          width: 84px;
+          height: 84px;
+          font-size: 1.7rem;
+        }
+
+        .study-identity-hero {
+          background: color-mix(in srgb, var(--accent) 5%, var(--ui-surface));
+          border-color: color-mix(in srgb, var(--accent) 22%, var(--line));
         }
 
         .study-identity-row {

--- a/components/ui/CorpusIndex.tsx
+++ b/components/ui/CorpusIndex.tsx
@@ -279,16 +279,20 @@ export default function CorpusIndex({
                    worst case (long labels wrapping) from crawling under the
                    fixed footer. */
                 .index-list {
-                    max-height: 520px;
+                    max-height: 560px;
                     overflow-y: auto;
                 }
 
+                /* Pager pinned to the card's bottom edge with breathing room —
+                   arrows always in the same place regardless of page length. */
                 .index-pager {
                     display: flex;
                     align-items: center;
                     justify-content: center;
-                    gap: 14px;
-                    padding-top: 10px;
+                    gap: 18px;
+                    margin-top: auto;
+                    padding: 14px 0 4px;
+                    border-top: 1px solid var(--line);
                 }
 
                 .index-pager-btn {

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -228,6 +228,8 @@
             "topLemmas": "أكثر الجذوع",
             "posMix": "مزيج الأنواع"
         },
+        "surahListExpand": "عرض كل السور ({count})",
+        "surahListCollapse": "عرض أقل",
         "surahInsight": {
             "title": "بطاقة السورة",
             "verses": "آيات",

--- a/messages/en.json
+++ b/messages/en.json
@@ -228,6 +228,8 @@
             "topLemmas": "Frequent lemmas",
             "posMix": "POS mix"
         },
+        "surahListExpand": "Show all {count} surahs",
+        "surahListCollapse": "Show fewer",
         "surahInsight": {
             "title": "Surah dossier",
             "verses": "verses",


### PR DESCRIPTION
## Profile ("Your Profile" page redesign)
- Identity is now the page hero — avatar (84px), editable display name, email — above the study tabs instead of hidden in "Data and account".
- Fixed: name field stayed empty after auth hydration (draft never adopted the stored value; also restores a dropped `useEffect` import).

## Search page
- **Corpus index overflow**: the component painted its own panel slab past the card's boundary (`height:100%` + own background) — now transparent, card supplies the surface.
- **Pager**: pinned to the card bottom behind a hairline, larger touch targets.
- **Root dossier**: surah distribution no longer caps at 6 — "Show all {n} surahs" toggle (verified: حمد expands 6 → 40 rows).

## Test plan
- [x] lint / tsc / 181 tests / i18n sync (1179 keys)
- [x] Live-verified: profile hero with hydrated name (dev-auth), dossier toggle 6→40, index card clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Branch complete — safe to merge.