### PR TITLE
fix(pwa): retire the old slate-blue chrome - splash, theme-color, icons, OG art

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,14 +32,25 @@ const amiri = Amiri({
   display: "swap",
 });
 
-export const viewport: Viewport = {
-  width: "device-width",
-  initialScale: 1,
-  // Let the app draw into the safe-area insets on notched/rounded-corner
-  // phones — the CSS already reads env(safe-area-inset-*) in several
-  // places (e.g. the footer), which otherwise no-ops without this.
-  viewportFit: "cover",
-};
+export async function generateViewport(): Promise<Viewport> {
+  // themeColor must match the shell background the user actually gets
+  // (cookie-driven data-theme, dark by default) — a static value painted
+  // the browser/PWA chrome the old slate blue regardless of theme.
+  const cookieStore = await cookies();
+  const { theme } = parseThemePreferenceCookie(
+    cookieStore.get(THEME_COOKIE_NAME)?.value
+  );
+
+  return {
+    width: "device-width",
+    initialScale: 1,
+    // Let the app draw into the safe-area insets on notched/rounded-corner
+    // phones — the CSS already reads env(safe-area-inset-*) in several
+    // places (e.g. the footer), which otherwise no-ops without this.
+    viewportFit: "cover",
+    themeColor: theme === "light" ? "#f7f3ea" : "#0e161a",
+  };
+}
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://quranobservatory.org"),

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -11,8 +11,10 @@ export default function manifest(): MetadataRoute.Manifest {
     scope: "/",
     display: "standalone",
     orientation: "any",
-    background_color: "#05070d",
-    theme_color: "#0f172a",
+    // Match the dark shell (--bg-0) so the install splash and app chrome
+    // don't flash the old slate blue before the app paints.
+    background_color: "#0e161a",
+    theme_color: "#0e161a",
     lang: "en",
     dir: "auto",
     categories: ["education", "reference", "productivity"],

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -15,7 +15,7 @@ export default async function OGImage() {
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          background: "linear-gradient(135deg, #0a0a0f 0%, #1a1a2e 40%, #16213e 70%, #0f3460 100%)",
+          background: "linear-gradient(135deg, #0a1013 0%, #0e161a 45%, #142026 78%, #1a2b33 100%)",
           fontFamily: "system-ui, sans-serif",
         }}
       >
@@ -27,7 +27,7 @@ export default async function OGImage() {
             width: "400px",
             height: "400px",
             borderRadius: "50%",
-            background: "radial-gradient(circle, rgba(99,179,237,0.15) 0%, transparent 70%)",
+            background: "radial-gradient(circle, rgba(86,166,151,0.16) 0%, transparent 70%)",
             display: "flex",
           }}
         />
@@ -39,7 +39,7 @@ export default async function OGImage() {
             width: "300px",
             height: "300px",
             borderRadius: "50%",
-            background: "radial-gradient(circle, rgba(129,140,248,0.12) 0%, transparent 70%)",
+            background: "radial-gradient(circle, rgba(232,146,74,0.12) 0%, transparent 70%)",
             display: "flex",
           }}
         />
@@ -47,7 +47,7 @@ export default async function OGImage() {
           style={{
             fontSize: 64,
             fontWeight: 800,
-            background: "linear-gradient(90deg, #63b3ed, #818cf8)",
+            background: "linear-gradient(90deg, #56a697, #e8924a)",
             backgroundClip: "text",
             color: "transparent",
             display: "flex",
@@ -78,11 +78,11 @@ export default async function OGImage() {
               style={{
                 padding: "10px 24px",
                 borderRadius: "999px",
-                border: "1px solid rgba(99,179,237,0.3)",
+                border: "1px solid rgba(86,166,151,0.35)",
                 color: "rgba(255,255,255,0.8)",
                 fontSize: 18,
                 display: "flex",
-                background: "rgba(99,179,237,0.08)",
+                background: "rgba(86,166,151,0.1)",
               }}
             >
               {label}

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -15,7 +15,7 @@ export default async function TwitterImage() {
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          background: "linear-gradient(135deg, #0a0a0f 0%, #1a1a2e 40%, #16213e 70%, #0f3460 100%)",
+          background: "linear-gradient(135deg, #0a1013 0%, #0e161a 45%, #142026 78%, #1a2b33 100%)",
           fontFamily: "system-ui, sans-serif",
         }}
       >
@@ -27,7 +27,7 @@ export default async function TwitterImage() {
             width: "400px",
             height: "400px",
             borderRadius: "50%",
-            background: "radial-gradient(circle, rgba(99,179,237,0.15) 0%, transparent 70%)",
+            background: "radial-gradient(circle, rgba(86,166,151,0.16) 0%, transparent 70%)",
             display: "flex",
           }}
         />
@@ -39,7 +39,7 @@ export default async function TwitterImage() {
             width: "300px",
             height: "300px",
             borderRadius: "50%",
-            background: "radial-gradient(circle, rgba(129,140,248,0.12) 0%, transparent 70%)",
+            background: "radial-gradient(circle, rgba(232,146,74,0.12) 0%, transparent 70%)",
             display: "flex",
           }}
         />
@@ -47,7 +47,7 @@ export default async function TwitterImage() {
           style={{
             fontSize: 64,
             fontWeight: 800,
-            background: "linear-gradient(90deg, #63b3ed, #818cf8)",
+            background: "linear-gradient(90deg, #56a697, #e8924a)",
             backgroundClip: "text",
             color: "transparent",
             display: "flex",
@@ -78,11 +78,11 @@ export default async function TwitterImage() {
               style={{
                 padding: "10px 24px",
                 borderRadius: "999px",
-                border: "1px solid rgba(99,179,237,0.3)",
+                border: "1px solid rgba(86,166,151,0.35)",
                 color: "rgba(255,255,255,0.8)",
                 fontSize: 18,
                 display: "flex",
-                background: "rgba(99,179,237,0.08)",
+                background: "rgba(86,166,151,0.1)",
               }}
             >
               {label}

--- a/public/icon-any.svg
+++ b/public/icon-any.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 512 512">
   <!-- Generator: Adobe Illustrator 30.2.1, SVG Export Plug-In . SVG Version: 2.1.1 Build 1)  -->
   <defs>
@@ -8,7 +8,7 @@
       }
 
       .st1 {
-        fill: #0f172a;
+        fill: #0e161a;
       }
     </style>
   </defs>

--- a/public/icon-maskable.svg
+++ b/public/icon-maskable.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 512 512">
   <!-- Generator: Adobe Illustrator 30.2.1, SVG Export Plug-In . SVG Version: 2.1.1 Build 1)  -->
   <defs>
@@ -8,7 +8,7 @@
       }
 
       .st1 {
-        fill: #0f172a;
+        fill: #0e161a;
       }
     </style>
   </defs>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,7 @@
 
-const SW_VERSION = "2";
+// v3: rebrand — new manifest colors/name + recolored icons (cache-first
+// would otherwise pin the old slate-blue splash on installed PWAs).
+const SW_VERSION = "3";
 const STATIC_CACHE = `qcv-static-${SW_VERSION}`;
 const PAGE_CACHE = `qcv-pages-${SW_VERSION}`;
 


### PR DESCRIPTION
## Summary

The installed PWA still splashed and framed itself in the pre-redesign slate blue (`#0f172a`). This retires it everywhere:

- **Manifest** — `background_color` `#05070d` / `theme_color` `#0f172a` → `#0e161a` (the dark shell's `--bg-0`), so the Android install splash and app chrome match the observatory slate-teal.
- **App icons** — `icon-any.svg` / `icon-maskable.svg` had a baked `#0f172a` background rect (the splash centers these on `background_color`) → recolored `#0e161a`.
- **Browser theme-color** — no `themeColor` existed, so browser/PWA chrome fell back to manifest blue. Viewport export converted to `generateViewport()` reading the theme cookie: `#0e161a` dark / `#f7f3ea` light, matching the shell the user actually has.
- **OG / Twitter share cards** — old blue/indigo gradient → dark slate-teal gradient with the theme's accent tokens (`#56a697` teal / `#e8924a` orange).
- **Service worker** — `SW_VERSION` 2 → 3: image/manifest caches are cache-first, so installed clients would have pinned the old splash assets indefinitely. Bump purges them on next activation.

Verified live on dev: served `manifest.webmanifest` carries the new name/colors and `/en` renders `<meta name="theme-color" content="#0e161a"/>`.

Note: this commit was pushed to `feature/mobile-polish` moments after #57 merged, so it needed its own PR — no other changes here.

## Verification

- `tsc --noEmit`, lint — pass.
- Manifest + theme-color meta checked against the running app.
- Installed PWAs update one launch after deploy (SW activation), or immediately on reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
