### PR TITLE
fix(mobile): AR/RTL audit - portal starvation, rail centering, language access, legacy colors

### DIFF
--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -3238,8 +3238,11 @@ button.site-footer-link {
     gap: 0.3rem;
   }
 
-  .ui-workspace-topbar-actions .header-button-group {
-    display: none;
+  /* Keep the language switcher reachable at this width instead of hiding
+     it — compact its pills so brand + lang + auth still fit a 390px row. */
+  .ui-workspace-topbar-actions .control-pill-btn {
+    padding: 4px 8px;
+    font-size: 0.68rem;
   }
 }
 
@@ -3466,6 +3469,17 @@ button.site-footer-link {
   align-items: center;
   justify-content: center;
   pointer-events: none;
+}
+
+@media (max-width: 980px) {
+  /* Below the toolbar's own mobile breakpoint the fixed graph toolbar
+     (z-index 45, above this overlay's z-index 10) sits over the bottom of
+     the viewport, clipping the vertically-centered empty-state card's CTA
+     row. Pad the bottom of the centering box by the toolbar's mobile
+     clearance so the card centers itself above it instead. */
+  .kg-empty-overlay {
+    padding-block-end: calc(var(--graph-toolbar-mobile-clearance, 78px) + var(--mobile-tools-bar-clearance, 72px));
+  }
 }
 
 .kg-empty-card {
@@ -6739,6 +6753,21 @@ button.site-footer-link {
     /* Clear the mobile AppShell rail strip (top-center icon bar) so the
        chip doesn't sit on top of its icons. */
     top: calc(var(--header-clearance) + 108px);
+  }
+}
+
+/* Collocation graph's "Heuristic estimate" honesty badge
+   (components/visualisations/CollocationNetworkGraph.tsx). Desktop offset
+   sits just under the intro chip's desktop row; on mobile the intro chip
+   itself moves down (see .viz-intro-chip above), so the badge has to move
+   further down too or the chip's pill hides it. */
+.collocation-heuristic-badge {
+  top: calc(var(--header-clearance) + 102px);
+}
+
+@media (max-width: 980px) {
+  .collocation-heuristic-badge {
+    top: calc(var(--header-clearance) + 152px);
   }
 }
 

--- a/app/[locale]/study/page.tsx
+++ b/app/[locale]/study/page.tsx
@@ -17,5 +17,5 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 }
 
 export default function StudyPage() {
-  return <StudyHub title="Study" />;
+  return <StudyHub />;
 }

--- a/components/embed/EmbedClient.tsx
+++ b/components/embed/EmbedClient.tsx
@@ -16,7 +16,7 @@ import type { CorpusToken } from "@/lib/schema/types";
 function VizFallback() {
   return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "center", width: "100%", height: "100%" }}>
-      <div style={{ width: 28, height: 28, border: "3px solid #ccc", borderTopColor: "#3b82f6", borderRadius: "50%", animation: "spin 0.8s linear infinite" }} />
+      <div style={{ width: 28, height: 28, border: "3px solid var(--line, rgba(148,163,184,0.3))", borderTopColor: "var(--accent, #56a697)", borderRadius: "50%", animation: "spin 0.8s linear infinite" }} />
     </div>
   );
 }

--- a/components/shell/JourneyRail.tsx
+++ b/components/shell/JourneyRail.tsx
@@ -397,6 +397,14 @@ export default function JourneyRail({ vizMode, onVizModeChange, isPanelCollapsed
                z-index) — without this offset the icon strip renders half
                underneath it. Pill is ~34px tall incl. its 6px margin. */
             top: calc(var(--header-clearance) + 48px);
+            /* Centering must go through the LOGICAL property: the CSS
+               compiler rewrites inset-inline-* into :lang()-guarded
+               physical rules whose selectors carry HIGHER specificity
+               (0,3,0) than a plain class rule, so a physical left: 50%
+               here (0,2,0) silently loses to the base rule's
+               inset-inline-start: 8px and the strip hangs off-screen.
+               In RTL this resolves to right: 50%, so the translateX flip
+               below (dir-scoped) completes the centering there. */
             inset-inline-start: 50%;
             transform: translateX(-50%);
             flex-direction: row;
@@ -406,6 +414,14 @@ export default function JourneyRail({ vizMode, onVizModeChange, isPanelCollapsed
             max-width: calc(100vw - 16px);
             padding: 6px 8px;
             border-radius: var(--radius-pill);
+          }
+
+          /* RTL half of the centering pair above: inset-inline-start: 50%
+             compiles to right: 50% there, so the shift must run +50%
+             (rightward) to land the strip centered instead of fully left
+             of center. */
+          :global([dir="rtl"]) .journey-rail {
+            transform: translateX(50%);
           }
 
           .rail-group {

--- a/components/ui/DisplaySettingsPanel.tsx
+++ b/components/ui/DisplaySettingsPanel.tsx
@@ -670,7 +670,7 @@ export default function DisplaySettingsPanel({
         }
 
         .toggle-switch.on {
-          background: var(--accent, #6366f1);
+          background: var(--accent);
         }
 
         .toggle-thumb {

--- a/components/ui/VizExplainer.tsx
+++ b/components/ui/VizExplainer.tsx
@@ -152,7 +152,7 @@ export default function VizExplainer({ vizMode }: VizExplainerProps) {
         }
 
         .viz-explainer-legend-item {
-          --viz-explainer-accent: #94a3b8;
+          --viz-explainer-accent: var(--ink-muted);
           position: relative;
           display: flex;
           align-items: center;

--- a/components/visualisations/ArcFlowDiagram.tsx
+++ b/components/visualisations/ArcFlowDiagram.tsx
@@ -157,11 +157,15 @@ export default function ArcFlowDiagram({
     setIsMounted(true);
     if (!containerRef.current) return;
 
+    // Floors guard against measuring a mid-layout zero/tiny rect, but they
+    // must stay BELOW real phone sizes: a 900px floor on a 390px viewport
+    // meant the whole layout was drawn for a 900-wide canvas and then
+    // squeezed to 43% by the viewBox, squashing the fan on mobile.
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         setDimensions({
-          width: Math.max(entry.contentRect.width, 900),
-          height: Math.max(entry.contentRect.height, 700),
+          width: Math.max(entry.contentRect.width, 320),
+          height: Math.max(entry.contentRect.height, 480),
         });
       }
     });
@@ -171,8 +175,8 @@ export default function ArcFlowDiagram({
     const rect = containerRef.current.getBoundingClientRect();
     if (rect.width > 0 && rect.height > 0) {
       setDimensions({
-        width: Math.max(rect.width, 900),
-        height: Math.max(rect.height, 700),
+        width: Math.max(rect.width, 320),
+        height: Math.max(rect.height, 480),
       });
     }
 

--- a/components/visualisations/AyahDependencyGraph.tsx
+++ b/components/visualisations/AyahDependencyGraph.tsx
@@ -682,7 +682,7 @@ export default function AyahDependencyGraph({
       <section className="immersive-viz dep-graph-wrapper" data-theme={theme}>
         {isMounted && typeof document !== "undefined" && document.getElementById("viz-sidebar-portal")
           ? createPortal(sidebarCards, document.getElementById("viz-sidebar-portal")!)
-          : sidebarCards}
+          : null}
         <div className="dep-empty-msg">{ts("noData")} {surahName}</div>
         <style jsx>{`
           .dep-graph-wrapper {
@@ -707,7 +707,7 @@ export default function AyahDependencyGraph({
     <section className="immersive-viz dep-graph-wrapper" data-theme={theme} style={{ width: "100%", height: "100%", position: "relative" }}>
       {isMounted && typeof document !== "undefined" && document.getElementById("viz-sidebar-portal")
         ? createPortal(sidebarCards, document.getElementById("viz-sidebar-portal")!)
-        : sidebarCards}
+        : null}
 
       <div ref={containerRef} className="dep-canvas-container">
         <svg

--- a/components/visualisations/CollocationNetworkGraph.tsx
+++ b/components/visualisations/CollocationNetworkGraph.tsx
@@ -1258,9 +1258,14 @@ export default function CollocationNetworkGraph({
                       so this is RTL-safe without any dir-specific branching),
                       and offset far enough below that chip's own row
                       (top: header-clearance + 58px, 36px tall) that the two
-                      never collide.
+                      never collide. The `top` offset lives in the
+                      .collocation-heuristic-badge CSS class (not inline)
+                      so it can be pushed down at <=980px, below the intro
+                      chip's own mobile position (header-clearance + 108px,
+                      ~36px tall) instead of hiding behind it.
                     */}
                     <span
+                        className="collocation-heuristic-badge"
                         title={t("HeuristicBadge.tooltip", { n: minFrequency })}
                         aria-label={`${t("HeuristicBadge.label")} — ${t("HeuristicBadge.tooltip", { n: minFrequency })}`}
                         tabIndex={0}
@@ -1268,7 +1273,6 @@ export default function CollocationNetworkGraph({
                             position: "absolute",
                             left: "50%",
                             transform: "translateX(-50%)",
-                            top: "calc(var(--header-clearance) + 102px)",
                             zIndex: 25,
                             display: "inline-flex",
                             alignItems: "center",

--- a/components/visualisations/RootFlowSankey.tsx
+++ b/components/visualisations/RootFlowSankey.tsx
@@ -692,7 +692,7 @@ export default function RootFlowSankey({
     <section className="sankey-wrapper">
       {isMounted && typeof document !== "undefined" && document.getElementById("viz-sidebar-portal")
         ? createPortal(sidebarCards, document.getElementById("viz-sidebar-portal")!)
-        : sidebarCards}
+        : null}
 
       {/* Scope + active root live in the StatusBar breadcrumb already — the
           only unique, actionable fact here is coverage, so this bar carries

--- a/docs/VIZ_ARCHITECTURE.md
+++ b/docs/VIZ_ARCHITECTURE.md
@@ -291,6 +291,43 @@ Fixed 2026-07-24 (branch `feature/mobile-polish`, mobile 390px pass; before/afte
 - PWA: `viewportFit: "cover"` added to the root viewport export (safe-area env()
   insets were no-ops on notched phones without it).
 
+Fixed 2026-07-24 later pass (branch `feature/ar-mobile-redesign`, AR/mobile audit;
+before `.ux-shots/ar-mobile-audit`, after `.ux-shots/mobile-final`):
+
+- **Portal-fallback canvas starvation (mobile).** AppShell mounts
+  `#viz-sidebar-portal` only while the mobile legend sheet is open, and
+  RootFlowSankey + AyahDependencyGraph fell back to rendering `sidebarCards`
+  INLINE inside the canvas wrapper when the target was absent — ~770px of
+  invisible cards starved sankey's SVG to 18px (users saw only the background
+  glow) and squashed the dependency tree. Fallback is now `null`, matching the
+  other seven vizzes. RULE: sidebar cards are portal-or-nothing — never inline.
+- **Arc-flow drawn for a phantom 900px canvas.** ArcFlowDiagram clamped its
+  measured width to `Math.max(width, 900)` (height 700), so a 390px phone drew
+  a 900-wide layout squeezed to 43% by the viewBox. Floors lowered to 320/480
+  (only guarding against mid-layout zero rects); the fan now fills the phone
+  viewport.
+- **Logical-vs-physical centering trap (the rail clip).** The CSS compiler
+  (Lightning CSS) rewrites `inset-inline-*` into `:lang()`-guarded physical
+  rules at HIGHER specificity (0,3,0) than the plain class rule that carried
+  them — so a later `left: 50%` (0,2,0) in JourneyRail's mobile block silently
+  lost to the base rule's `inset-inline-start: 8px`, and the strip hung half
+  off-screen (visually obvious in RTL, actually broken in BOTH directions).
+  Fix: center via `inset-inline-start: 50%` (same compiled specificity) +
+  `[dir="rtl"]`-scoped `translateX(50%)` flip. RULE: never mix a physical
+  override against a logical base property in this codebase — same property
+  group, but the compiled logical side wins on specificity.
+- Workspace pages ≤600px hid the LanguageSwitcher (`.header-button-group
+  { display: none }`) — language was unswitchable on search/study/quiz mobile.
+  Now compacted instead of hidden.
+- /ar study page h1 was hardcoded English (`<StudyHub title="Study" />`);
+  drops to the localized Profile.title fallback.
+- Old-palette stragglers tokenized: embed spinner #3b82f6, DisplaySettingsPanel
+  toggle fallback #6366f1, VizExplainer legend accent #94a3b8.
+- Collocation "Heuristic estimate" badge sat under the mobile intro chip →
+  dropped to header+152px; knowledge-graph empty-state CTA clipped by the
+  bottom toolbar → `.kg-empty-overlay` mobile padding-block-end clears
+  toolbar + tools-bar.
+
 Known, deliberately deferred (next iterations):
 
 - Lemma glosses missing for many forms ("Translation not available") — data gap, see
@@ -328,6 +365,10 @@ Known, deliberately deferred (next iterations):
   root form (plain alif) — both sites land on their search page for non-citation
   forms; if lookups miss for hamza-family roots (امن vs أمن), consider mapping to
   citation orthography before linking.
+- Sankey on mobile now renders (post portal-fix) but pins to the top of the
+  scroll area under the rail/status chrome (`preserveAspectRatio="xMidYMin"` +
+  no initial vertical fit) — needs a chrome-aware initial centering like the
+  other vizzes. Dependency-tree mobile still leaves dead space above the tree.
 - Mobile leftovers (2026-07-24 pass): the Ayah quick-filter placeholder still clips
   ("Ayah (e.g") at 390px; surah-distribution chart renders small with dead space on
   mobile (needs a viz-level responsive margin pass); the 900px (VizControlContext


### PR DESCRIPTION
## Summary

Full Arabic/mobile audit (13 surfaces × mobile viewport) surfaced four systemic breakages — all reproduced in EN too, AR just made them obvious. Root causes and fixes:

### The big ones

- **Portal fallback starved canvases.** AppShell mounts `#viz-sidebar-portal` on mobile only while the legend sheet is open. RootFlowSankey and AyahDependencyGraph fell back to rendering their sidebar cards **inline inside the canvas wrapper** when the target was absent — ~770px of invisible cards. Sankey's SVG collapsed to an 18px sliver (users saw only the background glow — reported as "broken/old colors"); the dependency tree got squashed to the bottom. Fallback is now `null`, matching the other seven vizzes.
- **Arc-flow drew for a phantom 900px canvas.** Measured width was clamped to `Math.max(width, 900)`, so a 390px phone rendered a 900-wide layout squeezed to 43% by the viewBox — the squashed vertical sliver of a fan. Floors lowered to 320/480; the fan now fills the phone viewport with readable labels.
- **JourneyRail strip hung half off-screen on every mobile page.** Lightning CSS rewrites `inset-inline-*` into `:lang()`-guarded physical rules at **higher specificity** (0,3,0) than plain class rules — so the mobile centering `left: 50%` (0,2,0) silently lost to the base `inset-inline-start: 8px` in both directions. Centering now goes through the logical property + a `[dir="rtl"]`-scoped `translateX(50%)` flip. Rule documented in VIZ_ARCHITECTURE.md + team memory: never override a logical base property with its physical alias here.
- **Language was unswitchable on search/study/quiz mobile** — `.header-button-group` was `display: none` ≤600px. Now compacted instead of hidden.

### Smaller fixes

- /ar study page h1 was hardcoded English (`<StudyHub title="Study" />`) → localized `Profile.title` fallback.
- Legacy blue-palette stragglers tokenized: embed spinner `#3b82f6`, DisplaySettingsPanel toggle fallback `#6366f1`, VizExplainer legend accent `#94a3b8`.
- Collocation "Heuristic estimate" badge no longer sits under the mobile intro chip; knowledge-graph empty-state CTA no longer clipped by the bottom toolbar.

### Deferred (ledger updated)

Sankey now renders on mobile but pins to the top under the chrome (needs chrome-aware initial centering); dependency-tree still leaves dead space above the tree; corpus-architecture/surah-distribution render small on portrait.

## Verification

- typecheck, lint, i18n key sync, 181 unit tests — all green.
- Before/after: `.ux-shots/ar-mobile-audit` → `.ux-shots/mobile-final` (26 shots: EN+AR, all 9 viz modes + home/search/study/quiz, 390px dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
