### PR TITLE
feat(search): partial prefix match for names (اسماع → اسماعيل)

### DIFF
--- a/lib/corpus/nameStatsClient.test.ts
+++ b/lib/corpus/nameStatsClient.test.ts
@@ -60,6 +60,14 @@ describe("lookupName", () => {
     expect(lookupName(idx, "mus")?.gloss).toBe("Moses");
   });
 
+  it("resolves a partial Arabic prefix to the closest name", () => {
+    expect(lookupName(idx, "موس")?.gloss).toBe("Moses"); // موس → موسى
+  });
+
+  it("does not prefix-match a query shorter than 3 chars", () => {
+    expect(lookupName(idx, "مو")).toBeNull();
+  });
+
   it("returns null for an unknown word", () => {
     expect(lookupName(idx, "زقزقة")).toBeNull();
     expect(lookupName(idx, "xyzzy")).toBeNull();
@@ -120,6 +128,11 @@ describe("name-stats.json data integrity", () => {
     const key = data.aliasIndex?.[normalizeArabicForSearch("سليمان")];
     expect(key, "سليمان alias missing").toBeDefined();
     expect(data.names[key!].gloss).toBe("Solomon");
+  });
+
+  it("resolves a partial prefix to the closest name (اسماع → اسماعيل)", () => {
+    expect(lookupName(data, "اسماع")?.gloss).toBe("Ishmael");
+    expect(lookupName(data, "ابراه")?.gloss).toBe("Abraham");
   });
 
   it("indexes multi-word compound names", () => {

--- a/lib/corpus/nameStatsClient.ts
+++ b/lib/corpus/nameStatsClient.ts
@@ -108,6 +108,29 @@ function buildTermIndex(idx: NameStatsIndex): Map<string, string> {
 
 const ARABIC_RE = /[؀-ۿ]/;
 
+/**
+ * Partial typing → closest name (اسماع → اسماعيل). Frequency-ranked prefix over
+ * the name keys and alias keys, preferring proper nouns over function words.
+ * Min 3 chars so a 1–2 letter prefix doesn't grab an arbitrary name.
+ */
+function prefixMatch(idx: NameStatsIndex, qn: string): NameStat | null {
+  if (qn.length < 3) return null;
+  let best: NameStat | null = null;
+  const consider = (e: NameStat | undefined) => {
+    if (!e) return;
+    if (!best) { best = e; return; }
+    const es = e.kind === "name" ? 1 : 0;
+    const bs = best.kind === "name" ? 1 : 0;
+    if (es !== bs) { if (es > bs) best = e; return; }
+    if (e.count > best.count) best = e;
+  };
+  for (const e of Object.values(idx.names)) if (e.key.startsWith(qn)) consider(e);
+  if (idx.aliasIndex) {
+    for (const [ak, ek] of Object.entries(idx.aliasIndex)) if (ak.startsWith(qn)) consider(idx.names[ek]);
+  }
+  return best;
+}
+
 // Single-letter proclitics (و/ف conjunctions, ب/ك/ل prepositions) that the
 // corpus splits into their own segments — a user may still type them glued to
 // the name ("ومريم"). Tried only after an exact/candidate miss, so names that
@@ -163,7 +186,8 @@ export function lookupName(idx: NameStatsIndex, query: string): NameStat | null 
         }
       }
     }
-    return null;
+    // Last resort: partial typing → closest name by prefix.
+    return prefixMatch(idx, wholeKey);
   }
 
   // Latin — English name / transliteration.

--- a/scripts/check-names-search.ts
+++ b/scripts/check-names-search.ts
@@ -52,6 +52,8 @@ async function main() {
     ["داوود", 16, "two-waw spelling of داود"],
     ["ذو القرنين", 3, "compound"],
     ["يأجوج ومأجوج", 2, "compound"],
+    ["اسماع", 12, "partial → اسماعيل"],
+    ["موس", 136, "partial → موسى"],
   ];
   for (const [q, expected, note] of EXTRA) {
     await input.fill(""); await input.fill(q); await input.press("Enter");


### PR DESCRIPTION
Partial typing now resolves to the closest name while the user is still typing.

`lookupName` had exact + alias + affix-strip matching but no **Arabic prefix** fallback, so a partial name returned "no match". Added a frequency-ranked prefix scan over the name + alias keys (min 3 chars, proper nouns preferred over function words) as the last resort.

- اسماع → إسماعيل, ابراه → إبراهيم, موس → موسى
- 1–2 char queries don't prefix-match (avoids grabbing an arbitrary name)
- Latin partials already worked (translit/gloss prefix); this closes the Arabic side

Tests: prefix unit + data-integrity + min-length guard; live smoke covers اسماع→اسماعيل and موس→موسى. `verify` green — 202 tests + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)