### PR TITLE
fix(home): highlight searched word in result carousel ayahs

### DIFF
--- a/app/api/corpus/occurrences/route.ts
+++ b/app/api/corpus/occurrences/route.ts
@@ -5,10 +5,11 @@ import { createClient } from "@/lib/supabase/server";
  * GET /api/corpus/occurrences?kind=root|lemma&term=<arabic>&limit=10
  *
  * Returns the FIRST `limit` distinct ayahs (sūrah order) that contain the given
- * root or lemma, each with its Uthmani text and the surface form(s) that
- * matched (so the client can highlight the searched word). Powers the home
- * search result's verse carousel — the total occurrence count comes from the
- * precomputed stats, so this only needs the preview set.
+ * root or lemma, each with its Uthmani text and the 1-indexed WORD POSITIONS
+ * that matched (so the client highlights the searched word by position — the
+ * corpus stores surface text as font-glyph presentation forms, so text
+ * comparison is unreliable). Powers the home search result's verse carousel;
+ * the total occurrence count comes from the precomputed stats.
  *
  * corpus_tokens / ayahs are anon-readable (RLS public SELECT), so no RPC.
  */
@@ -47,7 +48,7 @@ export async function GET(request: NextRequest) {
     //    first `limit` distinct ayahs even for high-frequency terms.
     const { data: toks, error: tErr } = await supabase
       .from("corpus_tokens")
-      .select("sura,ayah,text")
+      .select("sura,ayah,position")
       .eq(column, wanted)
       .order("sura", { ascending: true })
       .order("ayah", { ascending: true })
@@ -55,19 +56,19 @@ export async function GET(request: NextRequest) {
       .limit(400);
     if (tErr) throw tErr;
 
-    // 2. First `limit` distinct ayahs, collecting matched surfaces per ayah.
+    // 2. First `limit` distinct ayahs, collecting matched word positions per ayah.
     const order: string[] = [];
-    const matches = new Map<string, Set<string>>();
+    const positions = new Map<string, Set<number>>();
     for (const t of toks ?? []) {
       const key = `${t.sura}:${t.ayah}`;
-      let set = matches.get(key);
+      let set = positions.get(key);
       if (!set) {
         if (order.length >= limit) continue;
-        set = new Set<string>();
-        matches.set(key, set);
+        set = new Set<number>();
+        positions.set(key, set);
         order.push(key);
       }
-      if (t.text) set.add(t.text);
+      if (typeof t.position === "number") set.add(t.position);
     }
     if (order.length === 0) return NextResponse.json({ ayahs: [] });
 
@@ -85,7 +86,7 @@ export async function GET(request: NextRequest) {
         sura,
         ayah,
         text: textById.get(key) ?? "",
-        matches: [...(matches.get(key) ?? [])],
+        positions: [...(positions.get(key) ?? [])].sort((a, b) => a - b),
       };
     });
 

--- a/components/home/MinimalHome.tsx
+++ b/components/home/MinimalHome.tsx
@@ -788,7 +788,6 @@ function ResultPanel({
           verses={verses}
           color={color}
           total={stat.verses}
-          matchTerm={fetchTerm}
           t={t}
           onOpenAyah={onOpenAyah}
           onOpenFull={() => (isName ? onExploreName(stat) : onExplore(stat.bare, "radial-sura", stat.first?.sura ?? stat.top[0]?.[0]))}
@@ -839,7 +838,6 @@ function ResultVerses({
   verses,
   color,
   total,
-  matchTerm,
   t,
   onOpenAyah,
   onOpenFull,
@@ -847,7 +845,6 @@ function ResultVerses({
   verses: OccurrenceAyah[];
   color: string;
   total: number;
-  matchTerm: string;
   t: ReturnType<typeof useTranslations>;
   onOpenAyah: (sura: number, ayah: number) => void;
   onOpenFull: () => void;
@@ -894,25 +891,20 @@ function ResultVerses({
     }
   };
 
-  // Highlight the searched word(s) within an ayah by normalized comparison, so
-  // Uthmani orthography / diacritics don't defeat the match.
-  const matchSet = useMemo(() => {
-    const s = new Set<string>();
-    for (const v of verses) for (const m of v.matches) s.add(normalizeArabicForSearch(m));
-    const term = normalizeArabicForSearch(matchTerm);
-    if (term) s.add(term);
-    return s;
-  }, [verses, matchTerm]);
-
-  const renderText = (text: string) =>
-    text.split(/\s+/).filter(Boolean).map((word, j) => {
-      const hl = matchSet.has(normalizeArabicForSearch(word));
+  // Highlight the searched word(s) by POSITION — the corpus stores surface text
+  // as font-glyph presentation forms, so the API returns the matched 1-indexed
+  // word positions instead, and we mark the ayah's Nth word.
+  const renderText = (ayah: OccurrenceAyah) => {
+    const hit = new Set(ayah.positions);
+    return ayah.text.split(/\s+/).filter(Boolean).map((word, j) => {
+      const hl = hit.has(j + 1);
       return (
         <span key={j} className={hl ? "mhome-verse-hl" : undefined} style={hl ? { color } : undefined}>
           {word}{" "}
         </span>
       );
     });
+  };
 
   const ex = verses[idx];
   const hasMore = total > n;
@@ -935,7 +927,7 @@ function ResultVerses({
               title={`${surahName(ex.sura)} ${ex.sura}:${ex.ayah}`}
               aria-expanded={false}
             >
-              <p dir="rtl" lang="ar" className="mhome-verse-ar">{renderText(ex.text)}</p>
+              <p dir="rtl" lang="ar" className="mhome-verse-ar">{renderText(ex)}</p>
               <span className="mhome-verse-ref">
                 <span className="mhome-verse-name">{surahName(ex.sura)}</span>
                 <span className="mhome-verse-num">{ex.sura}:{ex.ayah}</span>
@@ -969,7 +961,7 @@ function ResultVerses({
           <div className="mhome-rv-list">
             {verses.map((v, i) => (
               <button key={i} type="button" className="mhome-rv-row" onClick={() => onOpenAyah(v.sura, v.ayah)}>
-                <p dir="rtl" lang="ar" className="mhome-rv-ar">{renderText(v.text)}</p>
+                <p dir="rtl" lang="ar" className="mhome-rv-ar">{renderText(v)}</p>
                 <span className="mhome-rv-ref">
                   <span className="mhome-verse-name">{surahName(v.sura)}</span>
                   <span className="mhome-verse-num">{v.sura}:{v.ayah}</span>

--- a/lib/corpus/occurrencesClient.ts
+++ b/lib/corpus/occurrencesClient.ts
@@ -10,8 +10,8 @@ export interface OccurrenceAyah {
   ayah: number;
   /** Uthmani ayah text. */
   text: string;
-  /** Surface form(s) of the searched word in this ayah (for highlighting). */
-  matches: string[];
+  /** 1-indexed word positions of the searched word in this ayah (for highlight). */
+  positions: number[];
 }
 
 export async function fetchOccurrences(

--- a/scripts/check-names-search.ts
+++ b/scripts/check-names-search.ts
@@ -78,7 +78,7 @@ async function main() {
   } catch (e) { failures++; console.log(`❌ API /occurrences → ${(e as Error).message.split("\n")[0]}`); }
 
   // UI: carousel shows for a root search, expands to a list, offers full-corpus CTA.
-  for (const [q, kind] of [["رحم", "root"], ["موسى", "name"]] as const) {
+  for (const [q, kind] of [["رحم", "root"], ["موسى", "name"], ["اسماعيل", "name"]] as const) {
     await page.goto(`${BASE}/en`);
     const si = page.locator(".mhome-search input");
     await si.waitFor({ state: "visible", timeout: 30000 });
@@ -89,9 +89,10 @@ async function main() {
       await page.waitForSelector(".mhome-rv-list", { state: "visible", timeout: 6000 });
       const rows = await page.locator(".mhome-rv-row").count();
       const hasMore = await page.locator(".mhome-rv-more").count();
-      const ok = rows > 0;
+      const highlights = await page.locator(".mhome-rv-list .mhome-verse-hl").count();
+      const ok = rows > 0 && highlights > 0;
       if (!ok) failures++;
-      console.log(`${ok ? "✅" : "❌"} CAROUSEL ${q} (${kind}) → ${rows} ayahs listed, full-corpus CTA=${hasMore > 0}`);
+      console.log(`${ok ? "✅" : "❌"} CAROUSEL ${q} (${kind}) → ${rows} ayahs, ${highlights} highlighted, CTA=${hasMore > 0}`);
       if (q === "رحم") await page.screenshot({ path: `${SHOTS}/carousel-rahm.png` });
     } catch (e) { failures++; console.log(`❌ CAROUSEL ${q} → ${(e as Error).message.split("\n")[0]}`); }
   }


### PR DESCRIPTION
The result carousel wasn't highlighting the matched word (reported for إسماعيل; roots too).

**Root cause:** `corpus_tokens.text` stores surface forms as font-glyph **presentation forms** (ﭓﭔ / ﯚ), so comparing them to the standard-Arabic ayah text never matched — and roots have no single surface to compare against.

**Fix:** highlight by **word position**, not text. `/api/corpus/occurrences` now returns the matched 1-indexed word positions per ayah (`corpus_tokens.position`); the carousel marks the ayah's Nth word. Orthography-independent — handles Uthmani superscript-alef spellings (إِسْمَٰعِيل, ٱلرَّحْمَٰن) and proclitic-prefixed words.

**Verified live:** رحم → 12 highlighted, موسى → 10, إسماعيل → 3 (was 0). `verify` green — 209 tests + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)