### PR TITLE
fix(viz): sankey focuses deep-linked root; center left dock toggle

### DIFF
--- a/components/shell/JourneyRail.tsx
+++ b/components/shell/JourneyRail.tsx
@@ -246,7 +246,10 @@ export default function JourneyRail({ vizMode, onVizModeChange, isPanelCollapsed
            look identical there. */
         @media (min-width: 981px) {
           .journey-rail.in-dock {
-            position: static;
+            /* relative (not static) so the collapse toggle can be absolutely
+               centered against the full-height rail — mirrors the right
+               drawer's vertically-centered edge handle. */
+            position: relative;
             top: auto;
             inset-inline-start: auto;
             z-index: auto;
@@ -265,6 +268,17 @@ export default function JourneyRail({ vizMode, onVizModeChange, isPanelCollapsed
             background: transparent;
             border-color: transparent;
             box-shadow: none;
+          }
+
+          /* Center the collapse/expand toggle on the rail edge (screen middle),
+             consistent with the right inspector drawer's edge handle, instead of
+             pinning it to the rail's bottom. */
+          .journey-rail.in-dock .rail-bottom {
+            position: absolute;
+            top: 50%;
+            inset-inline: 0;
+            transform: translateY(-50%);
+            margin-top: 0;
           }
         }
 

--- a/components/visualisations/RootFlowSankey.tsx
+++ b/components/visualisations/RootFlowSankey.tsx
@@ -222,18 +222,31 @@ export default function RootFlowSankey({
     onTokenHover(null);
   }, [highlightRoot, onTokenHover]);
 
-  // Reset selected root if it's no longer available in the new scope
+  // Keep the selection in sync with the (streaming) scope:
+  //  • re-adopt a requested highlightRoot once it appears in availableRoots —
+  //    the corpus loads incrementally, so a deep-linked root can arrive after an
+  //    early reset left the graph on "all"; the adopt-on-change effect above
+  //    won't re-fire (highlightRoot didn't change), so this brings it back.
+  //  • otherwise drop a manually-chosen root that left the current scope.
   useEffect(() => {
+    if (availableRoots.length === 0) return;
+    if (highlightRoot && availableRoots.includes(highlightRoot)) {
+      if (selectedRoot !== highlightRoot) setSelectedRoot(highlightRoot);
+      return;
+    }
     if (selectedRoot !== "all" && !availableRoots.includes(selectedRoot)) {
       setSelectedRoot("all");
     }
-  }, [availableRoots, selectedRoot]);
+  }, [availableRoots, selectedRoot, highlightRoot]);
 
   useEffect(() => {
-    if (isBeginner) {
+    // Beginners default to the unfiltered "all" view — UNLESS a specific root
+    // was requested (deep link / home's "Compare forms"), which must win so the
+    // graph focuses on that root instead of showing every flow.
+    if (isBeginner && !highlightRoot) {
       setSelectedRoot("all");
     }
-  }, [isBeginner]);
+  }, [isBeginner, highlightRoot]);
 
   // 3. Apply root filtering
   const filteredFlows = useMemo(() => {


### PR DESCRIPTION
The final two items from the UI feedback:

**Sankey zoom/focus on the selected word** — Home's "Compare N forms" (and any `?root=` deep link) now filters + zooms the Root-Flow Sankey to that root instead of showing every flow. Two bugs: the beginner default forced `"all"` even when a root was requested, and the scope-reset fired while the corpus was still streaming (availableRoots momentarily empty), dropping the root before it was adopted. Now an explicit `highlightRoot` wins over the beginner default and the effect **re-adopts** the root once it appears in the streaming scope. (رحم → its 5 forms, "5 of 5 flows".)

**Left dock toggle centering** — the collapse/expand toggle is now vertically centered on the rail edge (desktop) to match the right inspector drawer's edge handle, instead of pinned to the rail bottom. (center y ≈ 520, was ≈ 910.)

`verify` green — 209 tests + build. Both live-verified via screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)