### PR TITLE
fix(home): focus + highlight the clicked carousel ayah in the radial graph

### DIFF
--- a/components/home/MinimalHome.tsx
+++ b/components/home/MinimalHome.tsx
@@ -374,8 +374,13 @@ export default function MinimalHome() {
 
   // Open one specific ayah (from the result verse carousel) in the observatory.
   const openAyah = useCallback(
-    (s: number, a: number) => {
+    // `word` is the 1-indexed matched word position (from the occurrence API):
+    // deep-link it as the focused token so the graph highlights that exact
+    // ayah + the inspector shows the SEARCHED word — not the ayah's first
+    // proclitic (a bare ?ayah= resolves to word 1, e.g. the "وَ" conjunction).
+    (s: number, a: number, word?: number) => {
       const sp = new URLSearchParams({ viz: "radial-sura", surah: String(s), ayah: String(a), entry: "calm" });
+      if (word && word > 0) sp.set("token", `${s}:${a}:${word}`);
       router.push(`/${locale}?${sp.toString()}`);
     },
     [locale, router]
@@ -671,7 +676,7 @@ function ResultPanel({
   t: ReturnType<typeof useTranslations>;
   onExplore: (root?: string, viz?: string, surah?: number) => void;
   onExploreName: (stat: NameStat) => void;
-  onOpenAyah: (sura: number, ayah: number) => void;
+  onOpenAyah: (sura: number, ayah: number, word?: number) => void;
   onBack: () => void;
 }) {
   const color = rootColor(stat);
@@ -898,7 +903,7 @@ function ResultVerses({
   color: string;
   total: number;
   t: ReturnType<typeof useTranslations>;
-  onOpenAyah: (sura: number, ayah: number) => void;
+  onOpenAyah: (sura: number, ayah: number, word?: number) => void;
   onOpenFull: () => void;
 }) {
   const surahName = useSurahName();
@@ -1021,7 +1026,7 @@ function ResultVerses({
           </div>
           <div className="mhome-rv-list">
             {verses.map((v, i) => (
-              <button key={i} type="button" className="mhome-rv-row" onClick={() => onOpenAyah(v.sura, v.ayah)}>
+              <button key={i} type="button" className="mhome-rv-row" onClick={() => onOpenAyah(v.sura, v.ayah, v.positions[0])}>
                 <p dir="rtl" lang="ar" className="mhome-rv-ar">{renderText(v)}</p>
                 <span className="mhome-rv-ref">
                   <span className="mhome-verse-name">{surahName(v.sura)}</span>

--- a/components/home/VisualizationViewport.tsx
+++ b/components/home/VisualizationViewport.tsx
@@ -92,6 +92,7 @@ export default function VisualizationViewport({
             onTokenFocus={setFocusedTokenId}
             onRootSelect={handleRootSelect}
             highlightRoot={selectedRoot}
+            focusAyah={selectedAyahInSurah}
             theme={theme}
             lexicalColorMode={lexicalColorMode}
           />

--- a/components/visualisations/RadialSuraMap.tsx
+++ b/components/visualisations/RadialSuraMap.tsx
@@ -24,6 +24,14 @@ interface RadialSuraMapProps {
   onTokenFocus: (tokenId: string) => void;
   onRootSelect?: (root: string | null) => void;
   highlightRoot?: string | null;
+  /**
+   * Deep-linked ayah to highlight + frame on entry (e.g. from a home-search
+   * verse-carousel click). One-shot: applied once when this surah's geometry
+   * lands, then it never fights manual zoom/pan or later selections. Does NOT
+   * move the inspector — the caller sets the focused token separately so the
+   * SEARCHED word stays inspected, not the ayah's first proclitic.
+   */
+  focusAyah?: number | null;
   theme?: "light" | "dark";
   lexicalColorMode?: LexicalColorMode;
 }
@@ -137,6 +145,7 @@ export default function RadialSuraMap({
   onTokenFocus,
   onRootSelect,
   highlightRoot,
+  focusAyah,
   theme = "dark",
   lexicalColorMode = "theme",
 }: RadialSuraMapProps) {
@@ -1025,14 +1034,12 @@ export default function RadialSuraMap({
     if (tokenId) onTokenFocus(tokenId);
   }, [ayahTokenIdByAyahRoot, ayahTokenIdByAyah, onTokenFocus]);
 
-  // Clicking an overview tick both selects that ayah (same as clicking a
-  // detail-mode bar) and zooms into its neighborhood in DETAIL geometry —
-  // reusing the same fitBounds plumbing the deep-link one-shot focus uses —
-  // so the resulting scale reliably clears DETAIL_ZOOM_THRESHOLD and the view
-  // lands on a coherent sector (a handful of neighboring ayahs), not one
-  // isolated bar with nothing around it.
-  const handleOverviewTickSelect = useCallback((ayah: number) => {
-    handleAyahSelect(ayah);
+  // Zoom the camera into an ayah's neighborhood in DETAIL geometry (a handful
+  // of neighboring ayahs, not one isolated bar) — reused by both the overview
+  // tick-click and the deep-link one-shot focus. Pure camera move: no
+  // selection/inspector side effects, so a deep link can drive it without
+  // clobbering the caller's focused token.
+  const zoomToAyah = useCallback((ayah: number, duration: number) => {
     if (ayahCount <= 0) return;
 
     let minX = Infinity;
@@ -1079,9 +1086,51 @@ export default function RadialSuraMap({
 
     fitBounds(
       { x: minX, y: minY, width: boxW, height: boxH },
-      { padding: clickPadding, duration: motionSafeDuration(750) }
+      { padding: clickPadding, duration }
     );
-  }, [ayahCount, barsGeometryByAyah, fitBounds, handleAyahSelect, dimensions.width, dimensions.height]);
+  }, [ayahCount, barsGeometryByAyah, fitBounds, dimensions.width, dimensions.height]);
+
+  // Clicking an overview tick both selects that ayah (same as clicking a
+  // detail-mode bar) and zooms into its neighborhood so the landing scale
+  // reliably clears DETAIL_ZOOM_THRESHOLD.
+  const handleOverviewTickSelect = useCallback((ayah: number) => {
+    handleAyahSelect(ayah);
+    zoomToAyah(ayah, motionSafeDuration(750));
+  }, [handleAyahSelect, zoomToAyah]);
+
+  // Deep-link one-shot: a `focusAyah` (e.g. a home-search verse-carousel click
+  // routed as ?surah=&ayah=&token=) highlights that ayah in the graph AND
+  // frames the camera on it. Runs once, when this surah's real geometry lands.
+  // Deliberately does NOT call onTokenFocus: the deep link already set the
+  // focused token to the SEARCHED word, and re-focusing here would replace it
+  // with the ayah's representative token (back to an irrelevant proclitic).
+  const hasAppliedInitialAyahFocusRef = useRef(false);
+  useEffect(() => {
+    if (hasAppliedInitialAyahFocusRef.current) return;
+    if (!dimensionsReady || !isMounted) return;
+    if (focusAyah == null) return; // nothing to focus (or not yet resolved)
+    if (barsWithGeometry.length === 0) return; // this surah's tokens haven't landed
+    if (!isSurahDataComplete) return; // stub/shell data — isLargeSurah not trustworthy
+    if (!barsGeometryByAyah.has(focusAyah)) return; // target ayah's geometry not built yet
+
+    hasAppliedInitialAyahFocusRef.current = true;
+    // Stand down the root/ring entry-focus effects: this ayah owns the camera.
+    hasAppliedInitialFocusRef.current = true;
+    setSelectedAyah(focusAyah);
+    // Large surahs sit in overview at entry — zoom in so the highlighted ayah
+    // is actually legible. Small surahs already render the full detail ring
+    // (framed by the entry-fit effect), so the selection highlight alone reads.
+    if (isLargeSurah) zoomToAyah(focusAyah, 0);
+  }, [
+    focusAyah,
+    dimensionsReady,
+    isMounted,
+    barsWithGeometry,
+    isSurahDataComplete,
+    isLargeSurah,
+    barsGeometryByAyah,
+    zoomToAyah,
+  ]);
 
   // Overview hover/click hit-testing happens on ONE invisible annulus over
   // the tick band (rather than 286 separate fattened hit targets): the


### PR DESCRIPTION
## Problem
Clicking an ayah in the home-search verse carousel opened the radial sura graph but:
1. **Irrelevant inspector** — it locked on word 1 of the ayah (a bare `?ayah=` resolves to `{sura}:{ayah}:1`), usually a proclitic like the `وَ` conjunction, not the searched word.
2. **No highlight/focus** — the radial stayed at the surah overview; the target ayah was neither framed nor highlighted (the graph received no ayah/token to focus on).

## Fix
- **`MinimalHome.openAyah`** now deep-links the matched word position as `?token={sura}:{ayah}:{position}` (the carousel already carries the occurrence positions used for highlighting). The inspector now shows the **searched word** with its real root/lemma.
- **`RadialSuraMap`** gains a one-shot `focusAyah` prop: when the surah's geometry lands it selects that ayah (graph highlight) and, for large surahs, zooms into its neighborhood — reusing the overview tick-click camera path, refactored into a side-effect-free `zoomToAyah`. It deliberately does **not** call `onTokenFocus`, so the deep-linked searched-word token stays inspected, and it never fights manual zoom/pan afterwards.

## Verification
`npm run verify` green (lint + typecheck + 209 tests + build).

Live-verified via Playwright deep links:
- `2:255` → inspector **اللّٰه** (root ا ل ه), ayah 255 highlighted + zoomed.
- `1:2:4` → inspector **العالمین** (root ع ل م), ayah 2 bar + root-arc highlighted.
- No-token contrast (`2:13`) reproduced the old `وَ` bug — confirming the token is what restores relevance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)