### PR TITLE
fix(search): resolve modern-spelled words the corpus writes defectively (صالح)

### DIFF
--- a/lib/corpus/formIndexClient.test.ts
+++ b/lib/corpus/formIndexClient.test.ts
@@ -17,6 +17,17 @@ describe("form-index (surface word → root)", () => {
     expect(lookupFormRoot(idx, word)).toBe(root);
   });
 
+  // Rasm fold: the corpus writes these defectively (صلح, رحمن), but users type
+  // the modern spelling with the medial alef — both must reach the root.
+  it.each([
+    ["صالح", "صلح"],
+    ["الصالحين", "صلح"],
+    ["صالحات", "صلح"],
+    ["رحمان", "رحم"],
+  ])("rasm-folds %s → root %s", (word, root) => {
+    expect(lookupFormRoot(idx, word)).toBe(root);
+  });
+
   it("returns null for a non-word", () => {
     expect(lookupFormRoot(idx, "زقزقةxyz")).toBeNull();
   });

--- a/lib/corpus/formIndexClient.ts
+++ b/lib/corpus/formIndexClient.ts
@@ -33,12 +33,33 @@ export async function loadFormIndex(): Promise<FormIndex> {
 
 const PROCLITIC = /^(وال|فال|بال|كال|لل|ال|و|ف|ب|ك|ل)/;
 
+/**
+ * Fold the modern (imlāʾī) spelling toward the corpus's Uthmani rasm by
+ * dropping the MEDIAL long-alef — the letter the rasm most commonly omits
+ * (صالح is written صلح, الصالحين → الصلحين, رحمان → رحمن). Keep the first and
+ * last letters so a leading article/hamza-alif or a genuine final alef is
+ * preserved. Used only as a fallback, so an over-fold that finds nothing is
+ * harmless; the win is that a naturally-typed word like صالح now resolves.
+ */
+function foldRasmAlef(s: string): string {
+  if (s.length <= 2) return s;
+  return s[0] + s.slice(1, -1).replace(/ا/g, "") + s[s.length - 1];
+}
+
 /** Resolve an inflected surface word to its root's bare key, or null. */
 export function lookupFormRoot(idx: FormIndex, query: string): string | null {
   const q = normalizeArabicForSearch(query);
   if (!q) return null;
-  if (idx.forms[q]) return idx.forms[q];
-  const stripped = q.replace(PROCLITIC, "");
-  if (stripped.length >= 2 && idx.forms[stripped]) return idx.forms[stripped];
-  return null;
+  const resolve = (k: string): string | null => {
+    if (idx.forms[k]) return idx.forms[k];
+    const stripped = k.replace(PROCLITIC, "");
+    if (stripped.length >= 2 && idx.forms[stripped]) return idx.forms[stripped];
+    return null;
+  };
+  // Direct (imlāʾī) match first; then the rasm-folded spelling so words the
+  // corpus writes defectively (صالح → صلح) still reach their root.
+  const direct = resolve(q);
+  if (direct) return direct;
+  const folded = foldRasmAlef(q);
+  return folded !== q ? resolve(folded) : null;
 }


### PR DESCRIPTION
## Problem
Words like **صالح** were unsearchable. The corpus surface text is Uthmani **rasm**, which omits the medial long-alef (صالح is written `صلح`, الصالحين → `الصلحين`, رحمان → `رحمن`), so the form-index keys are alef-stripped. A naturally typed query keeps the alef, so `normalizeArabicForSearch("صالح")` never matched a form key — and the word resolved to nothing (not a root, not a name, not a form).

## Fix
`lookupFormRoot` now falls back to a **rasm-folded** spelling (drop the medial alef, keep first/last letter) when the direct lookup misses: صالح → صلح → root صلح. Fallback-only — an over-fold that finds nothing is harmless, and every previously-working direct case is untouched.

Covers a whole class: صالح / الصالحين / صالحات / رحمان all now reach their root.

## Verification
`npm run verify` green (lint + typecheck + tests + build); added 4 rasm-fold test cases.

Live-verified: searching **صالح** now resolves to root **ص-ل-ح** (180 occurrences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)